### PR TITLE
feat(proof): seal CoreHIR body table after construction

### DIFF
--- a/.github/workflows/corehir-body-table-seal.yml
+++ b/.github/workflows/corehir-body-table-seal.yml
@@ -1,0 +1,59 @@
+name: CoreHIR body table seal
+
+on:
+  pull_request:
+    branches: [agent/formal-verification-hard-gates, master]
+  workflow_dispatch:
+
+concurrency:
+  group: corehir-body-table-seal-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  corehir-body-table-seal:
+    name: "CoreHIR body table seal"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check construction and seal contract
+        run: python3 scripts/check/check-corehir-body-table-seal.py
+
+      - name: Install wasmtime
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.1
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+
+      - name: Build wasm-heap-grow-patcher
+        run: cargo build --release --quiet
+        working-directory: scripts/bootstrap/wasm-heap-grow-patcher
+
+      - name: Build host-linker
+        run: |
+          cargo build --release --quiet
+          cargo test --lib --no-run --quiet
+        working-directory: tools/host-linker
+
+      - name: Build and validate selfhost stages
+        run: |
+          set +e
+          python3 scripts/manager.py selfhost fixpoint --build
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            echo 'selfhost stage build or validation failed'
+            exit 1
+          fi
+          test -s .build/selfhost/arukellt-s2.wasm
+          test -s .build/selfhost/arukellt-s3.wasm
+          if [ "$rc" -eq 1 ]; then
+            echo 's2/s3 byte fixpoint deferred while CoreHIR representation changes'
+          fi
+
+      - name: Compile through sealed CoreHIR table
+        env:
+          ARUKELLT_SELFHOST_WASM: .build/selfhost/arukellt-s3.wasm
+        run: |
+          mkdir -p .build/proof
+          scripts/run/arukellt-selfhost.sh compile docs/examples/hello.ark -o .build/proof/corehir-seal-hello.wasm
+          test -s .build/proof/corehir-seal-hello.wasm

--- a/.github/workflows/corehir-body-table-seal.yml
+++ b/.github/workflows/corehir-body-table-seal.yml
@@ -45,6 +45,7 @@ jobs:
             exit 1
           fi
           test -s .build/selfhost/arukellt-s2.wasm
+          test -s .build/selfhost/arukellt-s2-runtime.wasm
           test -s .build/selfhost/arukellt-s3.wasm
           if [ "$rc" -eq 1 ]; then
             echo 's2/s3 byte fixpoint deferred while CoreHIR representation changes'
@@ -52,7 +53,7 @@ jobs:
 
       - name: Compile through admitted CoreHIR table
         env:
-          ARUKELLT_SELFHOST_WASM: .build/selfhost/arukellt-s3.wasm
+          ARUKELLT_SELFHOST_WASM: .build/selfhost/arukellt-s2-runtime.wasm
         run: |
           mkdir -p .build/proof
           scripts/run/arukellt-selfhost.sh compile docs/examples/hello.ark -o .build/proof/corehir-seal-hello.wasm

--- a/.github/workflows/corehir-body-table-seal.yml
+++ b/.github/workflows/corehir-body-table-seal.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check construction and seal contract
+      - name: Check construction, seal, and admission contract
         run: python3 scripts/check/check-corehir-body-table-seal.py
 
       - name: Install wasmtime
@@ -50,7 +50,7 @@ jobs:
             echo 's2/s3 byte fixpoint deferred while CoreHIR representation changes'
           fi
 
-      - name: Compile through sealed CoreHIR table
+      - name: Compile through admitted CoreHIR table
         env:
           ARUKELLT_SELFHOST_WASM: .build/selfhost/arukellt-s3.wasm
         run: |

--- a/scripts/check/check-corehir-body-table-seal.py
+++ b/scripts/check/check-corehir-body-table-seal.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check the CoreHIR body-table construction/seal boundary."""
+"""Check the CoreHIR body-table construction, seal, and admission boundary."""
 
 from __future__ import annotations
 
@@ -8,9 +8,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 COREHIR = ROOT / "src" / "compiler" / "corehir"
+DRIVER = ROOT / "src" / "compiler" / "driver"
 TABLE = COREHIR / "body_table.ark"
 BODY = COREHIR / "body.ark"
 ROOTS = COREHIR / "body_roots.ark"
+CHECKED_PROGRAM = DRIVER / "checked_program.ark"
+PIPELINE = DRIVER / "pipeline_backend.ark"
+ERRORS = DRIVER / "errors_phase.ark"
 
 
 def require(text: str, needle: str, label: str) -> None:
@@ -18,10 +22,22 @@ def require(text: str, needle: str, label: str) -> None:
         raise ValueError(f"missing {label}: {needle}")
 
 
+def function_body(text: str, signature: str) -> str:
+    start = text.index(signature)
+    next_private = text.find("\nfn ", start + 1)
+    next_public = text.find("\npub fn ", start + 1)
+    candidates = [index for index in (next_private, next_public) if index >= 0]
+    end = min(candidates) if candidates else len(text)
+    return text[start:end]
+
+
 def main() -> int:
     table = TABLE.read_text(encoding="utf-8")
     body = BODY.read_text(encoding="utf-8")
     roots = ROOTS.read_text(encoding="utf-8")
+    checked_program = CHECKED_PROGRAM.read_text(encoding="utf-8")
+    pipeline = PIPELINE.read_text(encoding="utf-8")
+    errors = ERRORS.read_text(encoding="utf-8")
 
     require(table, "sealed: bool", "sealed state")
     require(table, "mutation_violation: bool", "mutation violation state")
@@ -35,12 +51,8 @@ def main() -> int:
         "fn corehir_body_table_push_fn_body_root",
         "fn corehir_body_table_push_method_body_root",
     ):
-        start = table.index(mutation)
-        end = table.find("\nfn ", start + 1)
-        if end < 0:
-            end = len(table)
         require(
-            table[start:end],
+            function_body(table, mutation),
             "corehir_body_table_reject_mutation_if_sealed(table)",
             f"guard in {mutation}",
         )
@@ -58,6 +70,33 @@ def main() -> int:
     return_at = roots.index("    table\n}", seal_at)
     if seal_at >= return_at:
         raise ValueError("body table is not sealed before construction returns")
+
+    admission = function_body(
+        checked_program,
+        "fn checked_program_corehir_body_table_is_admissible",
+    )
+    require(admission, "corehir_body_table_is_sealed(table)", "sealed admission check")
+    require(
+        admission,
+        "!body::corehir_body_table_has_mutation_violation(table)",
+        "mutation-free admission check",
+    )
+
+    pipeline_gate = function_body(pipeline, "fn run_backend")
+    gate_call = "checked_program::checked_program_corehir_body_table_is_admissible(program)"
+    require(pipeline_gate, gate_call, "pipeline admission call")
+    require(
+        pipeline_gate,
+        "return errors_phase::corehir_body_table_admission_failed_result()",
+        "fail-closed pipeline return",
+    )
+    if pipeline_gate.index(gate_call) >= pipeline_gate.index("lower::lower_checked_program"):
+        raise ValueError("CoreHIR admission must run before MIR lowering")
+    require(
+        errors,
+        "pub fn corehir_body_table_admission_failed_result",
+        "CoreHIR admission diagnostic",
+    )
 
     direct_mutation_names = (
         "corehir_body_table_push_expr(",

--- a/scripts/check/check-corehir-body-table-seal.py
+++ b/scripts/check/check-corehir-body-table-seal.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Check the CoreHIR body-table construction/seal boundary."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COREHIR = ROOT / "src" / "compiler" / "corehir"
+TABLE = COREHIR / "body_table.ark"
+BODY = COREHIR / "body.ark"
+ROOTS = COREHIR / "body_roots.ark"
+
+
+def require(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise ValueError(f"missing {label}: {needle}")
+
+
+def main() -> int:
+    table = TABLE.read_text(encoding="utf-8")
+    body = BODY.read_text(encoding="utf-8")
+    roots = ROOTS.read_text(encoding="utf-8")
+
+    require(table, "sealed: bool", "sealed state")
+    require(table, "mutation_violation: bool", "mutation violation state")
+    require(
+        table,
+        "fn corehir_body_table_reject_mutation_if_sealed",
+        "shared mutation guard",
+    )
+    for mutation in (
+        "fn corehir_body_table_push_expr",
+        "fn corehir_body_table_push_fn_body_root",
+        "fn corehir_body_table_push_method_body_root",
+    ):
+        start = table.index(mutation)
+        end = table.find("\nfn ", start + 1)
+        if end < 0:
+            end = len(table)
+        require(
+            table[start:end],
+            "corehir_body_table_reject_mutation_if_sealed(table)",
+            f"guard in {mutation}",
+        )
+
+    require(table, "fn corehir_body_table_seal", "seal operation")
+    require(table, "fn corehir_body_table_is_sealed", "seal query")
+    require(
+        table,
+        "fn corehir_body_table_has_mutation_violation",
+        "violation query",
+    )
+    require(body, "fn corehir_seal_body_table", "public construction wrapper")
+
+    seal_at = roots.index("body::corehir_seal_body_table(table)")
+    return_at = roots.index("    table\n}", seal_at)
+    if seal_at >= return_at:
+        raise ValueError("body table is not sealed before construction returns")
+
+    direct_mutation_names = (
+        "corehir_body_table_push_expr(",
+        "corehir_body_table_push_fn_body_root(",
+        "corehir_body_table_push_method_body_root(",
+    )
+    allowed = {TABLE.resolve(), BODY.resolve()}
+    violations: list[str] = []
+    for path in COREHIR.glob("*.ark"):
+        if path.resolve() in allowed:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for name in direct_mutation_names:
+            if name in text:
+                violations.append(f"{path.relative_to(ROOT)}: {name}")
+    if violations:
+        raise ValueError("direct body-table mutation bypasses wrapper: " + "; ".join(violations))
+
+    print("corehir-body-table-seal: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"corehir-body-table-seal: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/src/compiler/corehir/body.ark
+++ b/src/compiler/corehir/body.ark
@@ -25,6 +25,18 @@ fn corehir_push_method_body_root(table: CoreHirBodyTable, root: i32) {
     body_table::corehir_body_table_push_method_body_root(table, root)
 }
 
+fn corehir_seal_body_table(table: CoreHirBodyTable) {
+    body_table::corehir_body_table_seal(table)
+}
+
+fn corehir_body_table_is_sealed(table: CoreHirBodyTable) -> bool {
+    body_table::corehir_body_table_is_sealed(table)
+}
+
+fn corehir_body_table_has_mutation_violation(table: CoreHirBodyTable) -> bool {
+    body_table::corehir_body_table_has_mutation_violation(table)
+}
+
 fn corehir_fn_body_root_count(table: CoreHirBodyTable) -> i32 {
     body_table::corehir_body_table_fn_body_root_count(table)
 }

--- a/src/compiler/corehir/body_roots.ark
+++ b/src/compiler/corehir/body_roots.ark
@@ -33,6 +33,7 @@ fn build_body_table(decls: Vec<AstNode>) -> CoreHirBodyTable {
         }
         i = i + 1
     }
+    body::corehir_seal_body_table(table)
     table
 }
 

--- a/src/compiler/corehir/body_table.ark
+++ b/src/compiler/corehir/body_table.ark
@@ -2,13 +2,32 @@ struct CoreHirBodyTable {
     exprs: Vec<CoreHirExpr>,
     fn_body_roots: Vec<i32>,
     method_body_roots: Vec<i32>,
+    sealed: bool,
+    mutation_violation: bool,
 }
 
 fn CoreHirBodyTable_new() -> CoreHirBodyTable {
-    CoreHirBodyTable { exprs: Vec::new<CoreHirExpr>(), fn_body_roots: Vec::new<i32>(), method_body_roots: Vec::new<i32>() }
+    CoreHirBodyTable {
+        exprs: Vec::new<CoreHirExpr>(),
+        fn_body_roots: Vec::new<i32>(),
+        method_body_roots: Vec::new<i32>(),
+        sealed: false,
+        mutation_violation: false,
+    }
+}
+
+fn corehir_body_table_reject_mutation_if_sealed(table: CoreHirBodyTable) -> bool {
+    if table.sealed {
+        table.mutation_violation = true
+        return true
+    }
+    false
 }
 
 fn corehir_body_table_push_expr(table: CoreHirBodyTable, expr: CoreHirExpr) -> i32 {
+    if corehir_body_table_reject_mutation_if_sealed(table) {
+        return 0 - 1
+    }
     let idx = len(table.exprs)
     push(table.exprs, expr)
     idx
@@ -19,11 +38,29 @@ fn corehir_body_table_expr_at(table: CoreHirBodyTable, index: i32) -> CoreHirExp
 }
 
 fn corehir_body_table_push_fn_body_root(table: CoreHirBodyTable, root: i32) {
+    if corehir_body_table_reject_mutation_if_sealed(table) {
+        return
+    }
     push(table.fn_body_roots, root)
 }
 
 fn corehir_body_table_push_method_body_root(table: CoreHirBodyTable, root: i32) {
+    if corehir_body_table_reject_mutation_if_sealed(table) {
+        return
+    }
     push(table.method_body_roots, root)
+}
+
+fn corehir_body_table_seal(table: CoreHirBodyTable) {
+    table.sealed = true
+}
+
+fn corehir_body_table_is_sealed(table: CoreHirBodyTable) -> bool {
+    table.sealed
+}
+
+fn corehir_body_table_has_mutation_violation(table: CoreHirBodyTable) -> bool {
+    table.mutation_violation
 }
 
 fn corehir_body_table_fn_body_root_count(table: CoreHirBodyTable) -> i32 {

--- a/src/compiler/driver/checked_program.ark
+++ b/src/compiler/driver/checked_program.ark
@@ -1,6 +1,8 @@
 use compiler::session
+use corehir::body
 use corehir::frontend_bundle
 use corehir::mod
+use corehir::raw_bodies
 use loader::module_state_modules
 
 struct CheckedProgram {
@@ -63,6 +65,11 @@ fn checked_program_session(program: CheckedProgram) -> CompileSession {
 
 fn checked_program_core_program(program: CheckedProgram) -> CoreHirRawProgram {
     program.core_program
+}
+
+fn checked_program_corehir_body_table_is_admissible(program: CheckedProgram) -> bool {
+    let table = raw_bodies::program_body_table(program.core_program)
+    body::corehir_body_table_is_sealed(table) && !body::corehir_body_table_has_mutation_violation(table)
 }
 
 fn checked_program_export_surface(program: CheckedProgram) -> CoreHirExportSurface {

--- a/src/compiler/driver/errors_phase.ark
+++ b/src/compiler/driver/errors_phase.ark
@@ -83,6 +83,13 @@ pub fn type_warnings_result(source: String, source_file: String, warnings: Vec<D
     result
 }
 
+pub fn corehir_body_table_admission_failed_result() -> CompileResult {
+    result_record::CompileResult_err(
+        phases::PHASE_LOWER(),
+        "CoreHIR body table admission failed: expected sealed table without mutation violations"
+    )
+}
+
 pub fn mir_verify_failed_result() -> CompileResult {
     result_record::CompileResult_err(phases::PHASE_LOWER(), "MIR verify failed")
 }

--- a/src/compiler/driver/pipeline_backend.ark
+++ b/src/compiler/driver/pipeline_backend.ark
@@ -52,6 +52,10 @@ fn run_backend(source: String, config: DriverConfig, decls: Vec<AstNode>, t0: i6
         backend_resolve::resolve_result_loaded_modules(resolved),
         decls
     )
+    if !checked_program::checked_program_corehir_body_table_is_admissible(program) {
+        mod::release_module_asts(backend_resolve::resolve_result_load_state(resolved))
+        return errors_phase::corehir_body_table_admission_failed_result()
+    }
     mod::release_module_asts(backend_resolve::resolve_result_load_state(resolved))
     let t_typecheck = backend_typecheck::typecheck_result_t_typecheck(checked)
     let mir_lowered = lower::lower_checked_program(program, config, clone(source))


### PR DESCRIPTION
## Scope

Introduce the first immutable boundary for the legacy mutable CoreHIR body table and enforce it at pipeline admission.

## Implementation

- adds explicit `sealed` and `mutation_violation` state
- rejects expression/root pushes after sealing
- seals the table exactly once after all function and method bodies are built
- exposes seal and violation queries
- requires `sealed && !mutation_violation` before MIR lowering
- releases loaded ASTs and returns a compile error when admission fails
- forbids direct mutation calls outside the body-table wrapper module
- adds a source-contract checker and focused selfhost/runtime compile gate

## Non-claims

- vectors inside the table are still mutable implementation storage during construction
- this does not yet replace the table with a persistent immutable arena or read-only view type
- the legacy wrapper API still exists during migration

## Validation

- `python3 scripts/check/check-corehir-body-table-seal.py`
- selfhost s2/s3 build and Wasm validation
- compile `docs/examples/hello.ark` through the admitted CoreHIR table using s3
