### PR TITLE
feat(proof): generate solver-bound proof receipts

### DIFF
--- a/.github/workflows/solver-bound-proof-receipts.yml
+++ b/.github/workflows/solver-bound-proof-receipts.yml
@@ -1,0 +1,53 @@
+name: Solver-bound proof receipts
+
+on:
+  pull_request:
+    branches: [agent/formal-verification-hard-gates, master]
+  workflow_dispatch:
+
+concurrency:
+  group: solver-bound-proof-receipts-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  solver-bound-proof-receipts:
+    name: "Solver-bound proof receipts"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run receipt generator tests
+        run: python3 -m unittest scripts.tests.test_solver_receipts
+
+      - name: Generate bound artifacts from raw solver output
+        run: |
+          mkdir -p .build/proof-generated
+          python3 scripts/gen/write-solver-receipts.py \
+            --subject tests/proof/verified-core.json \
+            --solver-output tests/proof/solver-results.txt \
+            --toolchain tests/proof/toolchain/toolchain.json \
+            --trust-manifest-output .build/proof-generated/trust-manifest.json \
+            --proof-receipt-output .build/proof-generated/proof-receipt.json
+
+      - name: Revalidate generated bindings independently
+        run: |
+          python3 - <<'PY'
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, "scripts")
+          from proof.trust import validate_bound_proof
+          validate_bound_proof(
+              Path("tests/proof/verified-core.json"),
+              Path(".build/proof-generated/trust-manifest.json"),
+              Path(".build/proof-generated/proof-receipt.json"),
+              Path("tests/proof/solver-results.txt"),
+          )
+          print("solver-bound-proof-receipts: PASS")
+          PY
+
+      - name: Upload generated receipts
+        uses: actions/upload-artifact@v4
+        with:
+          name: solver-bound-proof-receipts
+          path: .build/proof-generated
+          if-no-files-found: error

--- a/scripts/gen/write-solver-receipts.py
+++ b/scripts/gen/write-solver-receipts.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Generate SHA-bound TrustManifest and ProofReceipt artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.solver_receipts import generate_solver_receipts  # noqa: E402
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--subject", type=Path, required=True)
+    result.add_argument("--solver-output", type=Path, required=True)
+    result.add_argument("--toolchain", type=Path, required=True)
+    result.add_argument("--trust-manifest-output", type=Path, required=True)
+    result.add_argument("--proof-receipt-output", type=Path, required=True)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        _, receipt = generate_solver_receipts(
+            args.subject.resolve(),
+            args.solver_output.resolve(),
+            args.toolchain.resolve(),
+            args.trust_manifest_output.resolve(),
+            args.proof_receipt_output.resolve(),
+        )
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        print(f"write-solver-receipts: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "write-solver-receipts: PASS: "
+        f"status={receipt['status']} obligations={receipt['obligations']['total']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/proof/solver_receipts.py
+++ b/scripts/proof/solver_receipts.py
@@ -1,0 +1,267 @@
+"""Generate TrustManifest and ProofReceipt artifacts from solver output."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from proof.common import load_json, sha256_file
+from proof.trust import validate_bound_proof, validate_proof_receipt, validate_trust_manifest
+from proof.verified_core import validate_document as validate_verified_core
+
+TOOLCHAIN_SCHEMA = "arukellt-proof-toolchain"
+TOOLCHAIN_VERSION = 1
+
+_STATUS_MAP = {
+    "proved": "proved",
+    "unsat": "proved",
+    "refuted": "refuted",
+    "sat": "refuted",
+    "unknown": "unknown",
+    "error": "error",
+}
+
+
+def _require_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label}: expected object")
+    return value
+
+
+def _require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label}: expected non-empty string")
+    return value
+
+
+def _require_positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{label}: expected positive integer")
+    return value
+
+
+def _exact_keys(value: dict[str, Any], label: str, required: set[str], optional: set[str] = set()) -> None:
+    missing = required - value.keys()
+    if missing:
+        raise ValueError(f"{label}: missing field(s): {', '.join(sorted(missing))}")
+    unknown = value.keys() - required - optional
+    if unknown:
+        raise ValueError(f"{label}: unknown field(s): {', '.join(sorted(unknown))}")
+
+
+def _resolve_file(base: Path, raw: Any, label: str) -> Path:
+    value = _require_string(raw, label)
+    candidate = Path(value)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise ValueError(f"{label}: expected relative path without '..'")
+    resolved = (base / candidate).resolve()
+    if resolved != base and base not in resolved.parents:
+        raise ValueError(f"{label}: resolved path escapes toolchain directory")
+    if not resolved.is_file():
+        raise ValueError(f"{label}: missing file: {resolved}")
+    return resolved
+
+
+def _tool(value: Any, base: Path, label: str) -> dict[str, Any]:
+    tool = _require_object(value, label)
+    _exact_keys(tool, label, {"name", "version", "executable"}, {"arguments", "build_id"})
+    path = _resolve_file(base, tool["executable"], f"{label}.executable")
+    result: dict[str, Any] = {
+        "name": _require_string(tool["name"], f"{label}.name"),
+        "version": _require_string(tool["version"], f"{label}.version"),
+        "executable_sha256": sha256_file(path),
+    }
+    if "build_id" in tool:
+        result["build_id"] = _require_string(tool["build_id"], f"{label}.build_id")
+    if "arguments" in tool:
+        arguments = tool["arguments"]
+        if not isinstance(arguments, list) or any(not isinstance(item, str) for item in arguments):
+            raise ValueError(f"{label}.arguments: expected string array")
+        result["arguments"] = arguments
+    return result
+
+
+def load_toolchain(path: Path) -> dict[str, Any]:
+    value = _require_object(load_json(path), "toolchain")
+    _exact_keys(
+        value,
+        "toolchain",
+        {
+            "schema",
+            "schema_version",
+            "producer",
+            "translator",
+            "solver",
+            "semantic_profile",
+            "assumptions",
+            "trusted_components",
+            "limits",
+        },
+    )
+    if value["schema"] != TOOLCHAIN_SCHEMA:
+        raise ValueError(f"toolchain.schema: expected {TOOLCHAIN_SCHEMA!r}")
+    if value["schema_version"] != TOOLCHAIN_VERSION:
+        raise ValueError(f"toolchain.schema_version: expected {TOOLCHAIN_VERSION}")
+    return value
+
+
+def parse_solver_output(path: Path) -> dict[str, int | str]:
+    counts = {"proved": 0, "refuted": 0, "unknown": 0, "errors": 0}
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith(";") or line == "success":
+            continue
+        token = line
+        if ":" in token:
+            prefix, suffix = token.rsplit(":", 1)
+            if prefix.strip() and suffix.strip():
+                token = suffix.strip()
+        normalized = _STATUS_MAP.get(token.lower())
+        if normalized is None:
+            if token.lower().startswith("(error"):
+                normalized = "error"
+            else:
+                raise ValueError(f"solver output line {line_number}: unsupported result {line!r}")
+        if normalized == "error":
+            counts["errors"] += 1
+        else:
+            counts[normalized] += 1
+    total = counts["proved"] + counts["refuted"] + counts["unknown"] + counts["errors"]
+    if total == 0:
+        raise ValueError("solver output contains no obligations")
+    if counts["errors"]:
+        status = "error"
+    elif counts["refuted"]:
+        status = "refuted"
+    elif counts["unknown"]:
+        status = "unknown"
+    else:
+        status = "proved"
+    return {"total": total, **counts, "status": status}
+
+
+def _subject_ref(subject_path: Path) -> dict[str, Any]:
+    subject = validate_verified_core(load_json(subject_path))
+    return {
+        "schema": subject["schema"],
+        "schema_version": subject["schema_version"],
+        "sha256": sha256_file(subject_path),
+    }
+
+
+def build_trust_manifest(subject_path: Path, toolchain_path: Path) -> dict[str, Any]:
+    toolchain = load_toolchain(toolchain_path)
+    base = toolchain_path.parent.resolve()
+
+    profile = _require_object(toolchain["semantic_profile"], "toolchain.semantic_profile")
+    _exact_keys(profile, "toolchain.semantic_profile", {"integer_model", "overflow", "floating_point", "memory"})
+    semantic_profile = {
+        field: _require_string(profile[field], f"toolchain.semantic_profile.{field}")
+        for field in ("integer_model", "overflow", "floating_point", "memory")
+    }
+
+    assumptions = toolchain["assumptions"]
+    if not isinstance(assumptions, list) or any(not isinstance(item, str) or not item for item in assumptions):
+        raise ValueError("toolchain.assumptions: expected non-empty string array")
+    if len(set(assumptions)) != len(assumptions):
+        raise ValueError("toolchain.assumptions: duplicate assumption")
+
+    components_raw = toolchain["trusted_components"]
+    if not isinstance(components_raw, list) or not components_raw:
+        raise ValueError("toolchain.trusted_components: expected non-empty array")
+    components: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for index, raw in enumerate(components_raw):
+        label = f"toolchain.trusted_components[{index}]"
+        component = _require_object(raw, label)
+        _exact_keys(component, label, {"name", "role", "artifact"}, {"version"})
+        name = _require_string(component["name"], f"{label}.name")
+        role = _require_string(component["role"], f"{label}.role")
+        if (name, role) in seen:
+            raise ValueError(f"{label}: duplicate trusted component")
+        seen.add((name, role))
+        artifact_path = _resolve_file(base, component["artifact"], f"{label}.artifact")
+        rendered: dict[str, Any] = {
+            "name": name,
+            "role": role,
+            "artifact_sha256": sha256_file(artifact_path),
+        }
+        if "version" in component:
+            rendered["version"] = _require_string(component["version"], f"{label}.version")
+        components.append(rendered)
+
+    limits = _require_object(toolchain["limits"], "toolchain.limits")
+    _exact_keys(limits, "toolchain.limits", {"timeout_ms", "memory_bytes"})
+
+    manifest = {
+        "schema": "arukellt-trust-manifest",
+        "schema_version": 1,
+        "subject": _subject_ref(subject_path),
+        "producer": _tool(toolchain["producer"], base, "toolchain.producer"),
+        "translator": _tool(toolchain["translator"], base, "toolchain.translator"),
+        "solver": _tool(toolchain["solver"], base, "toolchain.solver"),
+        "semantic_profile": semantic_profile,
+        "assumptions": assumptions,
+        "trusted_components": components,
+        "limits": {
+            "timeout_ms": _require_positive_int(limits["timeout_ms"], "toolchain.limits.timeout_ms"),
+            "memory_bytes": _require_positive_int(limits["memory_bytes"], "toolchain.limits.memory_bytes"),
+        },
+    }
+    return validate_trust_manifest(manifest)
+
+
+def build_proof_receipt(
+    subject_path: Path,
+    trust_manifest_path: Path,
+    solver_output_path: Path,
+) -> dict[str, Any]:
+    parsed = parse_solver_output(solver_output_path)
+    receipt = {
+        "schema": "arukellt-proof-receipt",
+        "schema_version": 1,
+        "subject": _subject_ref(subject_path),
+        "trust_manifest_sha256": sha256_file(trust_manifest_path),
+        "solver_output_sha256": sha256_file(solver_output_path),
+        "status": parsed["status"],
+        "obligations": {
+            "total": parsed["total"],
+            "proved": parsed["proved"],
+            "refuted": parsed["refuted"],
+            "unknown": parsed["unknown"],
+            "errors": parsed["errors"],
+        },
+    }
+    return validate_proof_receipt(receipt)
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def generate_solver_receipts(
+    subject_path: Path,
+    solver_output_path: Path,
+    toolchain_path: Path,
+    trust_manifest_path: Path,
+    proof_receipt_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    manifest = build_trust_manifest(subject_path, toolchain_path)
+    write_json(trust_manifest_path, manifest)
+    receipt = build_proof_receipt(subject_path, trust_manifest_path, solver_output_path)
+    write_json(proof_receipt_path, receipt)
+    validate_bound_proof(subject_path, trust_manifest_path, proof_receipt_path, solver_output_path)
+    return manifest, receipt
+
+
+__all__ = [
+    "TOOLCHAIN_SCHEMA",
+    "TOOLCHAIN_VERSION",
+    "build_proof_receipt",
+    "build_trust_manifest",
+    "generate_solver_receipts",
+    "load_toolchain",
+    "parse_solver_output",
+]

--- a/scripts/tests/test_solver_receipts.py
+++ b/scripts/tests/test_solver_receipts.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.common import ValidationError, sha256_file  # noqa: E402
+from proof.solver_receipts import generate_solver_receipts, parse_solver_output  # noqa: E402
+from proof.trust import validate_bound_proof  # noqa: E402
+
+
+class SolverReceiptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proof_dir = ROOT / "tests" / "proof"
+        self.subject = self.proof_dir / "verified-core.json"
+        self.solver_output = self.proof_dir / "solver-results.txt"
+        self.toolchain = self.proof_dir / "toolchain" / "toolchain.json"
+
+    def test_parse_raw_solver_results(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "solver.txt"
+            path.write_text("unsat\nsat\nunknown\n(error bad)\n", encoding="utf-8")
+            parsed = parse_solver_output(path)
+        self.assertEqual(parsed["total"], 4)
+        self.assertEqual(parsed["proved"], 1)
+        self.assertEqual(parsed["refuted"], 1)
+        self.assertEqual(parsed["unknown"], 1)
+        self.assertEqual(parsed["errors"], 1)
+        self.assertEqual(parsed["status"], "error")
+
+    def test_unknown_solver_line_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "solver.txt"
+            path.write_text("probably-unsat\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "unsupported result"):
+                parse_solver_output(path)
+
+    def test_generate_bound_proved_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest_path = root / "trust-manifest.json"
+            receipt_path = root / "proof-receipt.json"
+            manifest, receipt = generate_solver_receipts(
+                self.subject,
+                self.solver_output,
+                self.toolchain,
+                manifest_path,
+                receipt_path,
+            )
+            validate_bound_proof(
+                self.subject,
+                manifest_path,
+                receipt_path,
+                self.solver_output,
+            )
+            toolchain = json.loads(self.toolchain.read_text(encoding="utf-8"))
+            solver_path = self.toolchain.parent / toolchain["solver"]["executable"]
+            self.assertEqual(manifest["solver"]["executable_sha256"], sha256_file(solver_path))
+            self.assertEqual(receipt["status"], "proved")
+            self.assertEqual(receipt["obligations"]["proved"], 1)
+
+    def test_modified_solver_output_invalidates_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output_copy = root / "solver-results.txt"
+            output_copy.write_text(self.solver_output.read_text(encoding="utf-8"), encoding="utf-8")
+            manifest_path = root / "trust-manifest.json"
+            receipt_path = root / "proof-receipt.json"
+            generate_solver_receipts(
+                self.subject,
+                output_copy,
+                self.toolchain,
+                manifest_path,
+                receipt_path,
+            )
+            output_copy.write_text("sat\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValidationError, "does not bind the supplied solver output"):
+                validate_bound_proof(
+                    self.subject,
+                    manifest_path,
+                    receipt_path,
+                    output_copy,
+                )
+
+    def test_empty_solver_output_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "solver.txt"
+            path.write_text("; no result\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "no obligations"):
+                parse_solver_output(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/proof/solver-results.txt
+++ b/tests/proof/solver-results.txt
@@ -1,0 +1,2 @@
+; one verification condition
+unsat

--- a/tests/proof/toolchain/producer.bin
+++ b/tests/proof/toolchain/producer.bin
@@ -1,0 +1,1 @@
+arukellt producer fixture

--- a/tests/proof/toolchain/solver.txt
+++ b/tests/proof/toolchain/solver.txt
@@ -1,0 +1,1 @@
+z3 solver fixture

--- a/tests/proof/toolchain/toolchain.json
+++ b/tests/proof/toolchain/toolchain.json
@@ -1,0 +1,39 @@
+{
+  "schema": "arukellt-proof-toolchain",
+  "schema_version": 1,
+  "producer": {
+    "name": "arukellt",
+    "version": "fixture",
+    "executable": "producer.bin"
+  },
+  "translator": {
+    "name": "arukellt-why3",
+    "version": "fixture",
+    "executable": "translator.txt"
+  },
+  "solver": {
+    "name": "z3",
+    "version": "fixture",
+    "executable": "solver.txt",
+    "arguments": ["-in", "-smt2"]
+  },
+  "semantic_profile": {
+    "integer_model": "mathematical",
+    "overflow": "checked",
+    "floating_point": "unsupported",
+    "memory": "pure-values"
+  },
+  "assumptions": [],
+  "trusted_components": [
+    {
+      "name": "arukellt-verified-core-v1",
+      "role": "artifact-validator",
+      "version": "1",
+      "artifact": "trusted-component.txt"
+    }
+  ],
+  "limits": {
+    "timeout_ms": 10000,
+    "memory_bytes": 1073741824
+  }
+}

--- a/tests/proof/toolchain/translator.txt
+++ b/tests/proof/toolchain/translator.txt
@@ -1,0 +1,1 @@
+arukellt why3 translator fixture

--- a/tests/proof/toolchain/trusted-component.txt
+++ b/tests/proof/toolchain/trusted-component.txt
@@ -1,0 +1,1 @@
+verified-core-v1 validator fixture


### PR DESCRIPTION
## Scope

Generate TrustManifest and ProofReceipt artifacts from raw solver results instead of relying on hand-written fixture hashes.

## Implementation

- adds strict `arukellt-proof-toolchain` v1 input handling
- hashes the exact producer, translator, solver, and trusted-component files
- parses fail-closed solver results (`unsat/sat/unknown/error` or canonical equivalents)
- maps solver outcomes to proved/refuted/unknown/error obligation counts
- emits SHA-bound TrustManifest and ProofReceipt v1 artifacts
- independently revalidates subject, manifest, receipt, and solver-output bindings after generation
- rejects unknown solver output and empty result sets
- includes a stale-solver-output negative test
- uploads generated receipts from CI

## Non-claims

- this does not invoke Why3 or Z3 yet; it consumes their captured output
- VC generation and solver process execution remain the next slice
- release policy remains proof-optional

## Validation

- `python3 -m unittest scripts.tests.test_solver_receipts`
- `python3 scripts/gen/write-solver-receipts.py ...`
- independent `validate_bound_proof(...)` over generated artifacts
