### PR TITLE
feat(proof): make solver results carry TrustManifest

### DIFF
--- a/.github/workflows/proof-solver-driver.yml
+++ b/.github/workflows/proof-solver-driver.yml
@@ -1,0 +1,65 @@
+name: Proof solver driver
+
+on:
+  pull_request:
+    branches: [agent/solver-bound-proof-receipts, agent/formal-verification-hard-gates, master]
+  workflow_dispatch:
+
+concurrency:
+  group: proof-solver-driver-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  proof-solver-driver:
+    name: "Proof solver driver"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable deterministic solver fixture
+        run: chmod +x tests/proof/toolchain/fake_solver.py
+
+      - name: Run solver and receipt tests
+        run: |
+          python3 -m unittest \
+            scripts.tests.test_solver_receipts \
+            scripts.tests.test_solver_driver
+
+      - name: Run a proved obligation end to end
+        run: |
+          mkdir -p .build/proof-run
+          python3 scripts/run/run-proof-solver.py \
+            --subject tests/proof/verified-core.json \
+            --solver-input tests/proof/solver-input.smt2 \
+            --toolchain tests/proof/toolchain/toolchain.json \
+            --solver-output .build/proof-run/solver-output.txt \
+            --trust-manifest-output .build/proof-run/trust-manifest.json \
+            --proof-receipt-output .build/proof-run/proof-receipt.json
+
+      - name: Require unknown to remain non-success
+        run: |
+          printf 'not-modelled\n' > .build/proof-run/unknown.smt2
+          set +e
+          python3 scripts/run/run-proof-solver.py \
+            --subject tests/proof/verified-core.json \
+            --solver-input .build/proof-run/unknown.smt2 \
+            --toolchain tests/proof/toolchain/toolchain.json \
+            --solver-output .build/proof-run/unknown-output.txt \
+            --trust-manifest-output .build/proof-run/unknown-trust-manifest.json \
+            --proof-receipt-output .build/proof-run/unknown-proof-receipt.json
+          rc=$?
+          set -e
+          test "$rc" -eq 2
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          receipt = json.loads(Path('.build/proof-run/unknown-proof-receipt.json').read_text())
+          assert receipt['status'] == 'unknown', receipt
+          PY
+
+      - name: Upload proof run artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: proof-solver-run
+          path: .build/proof-run
+          if-no-files-found: error

--- a/.github/workflows/proof-solver-driver.yml
+++ b/.github/workflows/proof-solver-driver.yml
@@ -16,13 +16,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Reject solver results without TrustManifest bundle
+        run: python3 scripts/check/check-solver-trust-manifest-boundary.py
+
       - name: Enable deterministic solver fixture
         run: chmod +x tests/proof/toolchain/fake_solver.py
 
-      - name: Run solver and receipt tests
+      - name: Run solver result and receipt tests
         run: |
           python3 -m unittest \
             scripts.tests.test_solver_receipts \
+            scripts.tests.test_solver_result \
             scripts.tests.test_solver_driver
 
       - name: Run a proved obligation end to end
@@ -34,7 +38,16 @@ jobs:
             --toolchain tests/proof/toolchain/toolchain.json \
             --solver-output .build/proof-run/solver-output.txt \
             --trust-manifest-output .build/proof-run/trust-manifest.json \
-            --proof-receipt-output .build/proof-run/proof-receipt.json
+            --proof-receipt-output .build/proof-run/proof-receipt.json \
+            --solver-result-output .build/proof-run/solver-result.json
+          python3 scripts/check/check-solver-result.py \
+            .build/proof-run/solver-result.json \
+            --subject tests/proof/verified-core.json \
+            --solver-input tests/proof/solver-input.smt2 \
+            --toolchain tests/proof/toolchain/toolchain.json \
+            --solver-output .build/proof-run/solver-output.txt \
+            --trust-manifest .build/proof-run/trust-manifest.json \
+            --proof-receipt .build/proof-run/proof-receipt.json
 
       - name: Require unknown to remain non-success
         run: |
@@ -46,18 +59,29 @@ jobs:
             --toolchain tests/proof/toolchain/toolchain.json \
             --solver-output .build/proof-run/unknown-output.txt \
             --trust-manifest-output .build/proof-run/unknown-trust-manifest.json \
-            --proof-receipt-output .build/proof-run/unknown-proof-receipt.json
+            --proof-receipt-output .build/proof-run/unknown-proof-receipt.json \
+            --solver-result-output .build/proof-run/unknown-solver-result.json
           rc=$?
           set -e
           test "$rc" -eq 2
+          python3 scripts/check/check-solver-result.py \
+            .build/proof-run/unknown-solver-result.json \
+            --subject tests/proof/verified-core.json \
+            --solver-input .build/proof-run/unknown.smt2 \
+            --toolchain tests/proof/toolchain/toolchain.json \
+            --solver-output .build/proof-run/unknown-output.txt \
+            --trust-manifest .build/proof-run/unknown-trust-manifest.json \
+            --proof-receipt .build/proof-run/unknown-proof-receipt.json
           python3 - <<'PY'
           import json
           from pathlib import Path
-          receipt = json.loads(Path('.build/proof-run/unknown-proof-receipt.json').read_text())
-          assert receipt['status'] == 'unknown', receipt
+          result = json.loads(Path('.build/proof-run/unknown-solver-result.json').read_text())
+          assert result['status'] == 'unknown', result
+          assert result['proof_receipt']['status'] == 'unknown', result
+          assert result['trust_manifest']['schema'] == 'arukellt-trust-manifest', result
           PY
 
-      - name: Upload proof run artifacts
+      - name: Upload complete proof run artifacts
         uses: actions/upload-artifact@v4
         with:
           name: proof-solver-run

--- a/.github/workflows/proof-solver-driver.yml
+++ b/.github/workflows/proof-solver-driver.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Reject solver results without TrustManifest bundle
         run: python3 scripts/check/check-solver-trust-manifest-boundary.py
 
+      - name: Write and independently validate solver trust receipt
+        run: |
+          python3 scripts/gen/write-solver-trust-boundary-receipt.py
+          python3 scripts/check/check-solver-trust-boundary-receipt.py \
+            .build/proof/solver-trust-boundary.json
+
       - name: Enable deterministic solver fixture
         run: chmod +x tests/proof/toolchain/fake_solver.py
 
@@ -27,6 +33,7 @@ jobs:
           python3 -m unittest \
             scripts.tests.test_solver_receipts \
             scripts.tests.test_solver_result \
+            scripts.tests.test_solver_trust_boundary_receipt \
             scripts.tests.test_solver_driver
 
       - name: Run a proved obligation end to end
@@ -85,5 +92,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: proof-solver-run
-          path: .build/proof-run
+          path: |
+            .build/proof-run
+            .build/proof/solver-trust-boundary.json
           if-no-files-found: error

--- a/.github/workflows/solver-bound-proof-receipts.yml
+++ b/.github/workflows/solver-bound-proof-receipts.yml
@@ -16,38 +16,41 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run receipt generator tests
-        run: python3 -m unittest scripts.tests.test_solver_receipts
+      - name: Reject detached solver result paths
+        run: python3 scripts/check/check-solver-trust-manifest-boundary.py
 
-      - name: Generate bound artifacts from raw solver output
+      - name: Run receipt and result tests
+        run: |
+          python3 -m unittest \
+            scripts.tests.test_solver_receipts \
+            scripts.tests.test_solver_result
+
+      - name: Generate complete result from captured solver output
         run: |
           mkdir -p .build/proof-generated
           python3 scripts/gen/write-solver-receipts.py \
             --subject tests/proof/verified-core.json \
+            --solver-input tests/proof/solver-input.smt2 \
             --solver-output tests/proof/solver-results.txt \
             --toolchain tests/proof/toolchain/toolchain.json \
             --trust-manifest-output .build/proof-generated/trust-manifest.json \
-            --proof-receipt-output .build/proof-generated/proof-receipt.json
+            --proof-receipt-output .build/proof-generated/proof-receipt.json \
+            --solver-result-output .build/proof-generated/solver-result.json
 
-      - name: Revalidate generated bindings independently
+      - name: Revalidate complete result independently
         run: |
-          python3 - <<'PY'
-          import sys
-          from pathlib import Path
-          sys.path.insert(0, "scripts")
-          from proof.trust import validate_bound_proof
-          validate_bound_proof(
-              Path("tests/proof/verified-core.json"),
-              Path(".build/proof-generated/trust-manifest.json"),
-              Path(".build/proof-generated/proof-receipt.json"),
-              Path("tests/proof/solver-results.txt"),
-          )
-          print("solver-bound-proof-receipts: PASS")
-          PY
+          python3 scripts/check/check-solver-result.py \
+            .build/proof-generated/solver-result.json \
+            --subject tests/proof/verified-core.json \
+            --solver-input tests/proof/solver-input.smt2 \
+            --toolchain tests/proof/toolchain/toolchain.json \
+            --solver-output tests/proof/solver-results.txt \
+            --trust-manifest .build/proof-generated/trust-manifest.json \
+            --proof-receipt .build/proof-generated/proof-receipt.json
 
-      - name: Upload generated receipts
+      - name: Upload complete captured result
         uses: actions/upload-artifact@v4
         with:
-          name: solver-bound-proof-receipts
+          name: solver-bound-proof-result
           path: .build/proof-generated
           if-no-files-found: error

--- a/.github/workflows/solver-bound-proof-receipts.yml
+++ b/.github/workflows/solver-bound-proof-receipts.yml
@@ -1,0 +1,53 @@
+name: Solver-bound proof receipts
+
+on:
+  pull_request:
+    branches: [agent/formal-verification-hard-gates, master]
+  workflow_dispatch:
+
+concurrency:
+  group: solver-bound-proof-receipts-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  solver-bound-proof-receipts:
+    name: "Solver-bound proof receipts"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run receipt generator tests
+        run: python3 -m unittest scripts.tests.test_solver_receipts
+
+      - name: Generate bound artifacts from raw solver output
+        run: |
+          mkdir -p .build/proof-generated
+          python3 scripts/gen/write-solver-receipts.py \
+            --subject tests/proof/verified-core.json \
+            --solver-output tests/proof/solver-results.txt \
+            --toolchain tests/proof/toolchain/toolchain.json \
+            --trust-manifest-output .build/proof-generated/trust-manifest.json \
+            --proof-receipt-output .build/proof-generated/proof-receipt.json
+
+      - name: Revalidate generated bindings independently
+        run: |
+          python3 - <<'PY'
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, "scripts")
+          from proof.trust import validate_bound_proof
+          validate_bound_proof(
+              Path("tests/proof/verified-core.json"),
+              Path(".build/proof-generated/trust-manifest.json"),
+              Path(".build/proof-generated/proof-receipt.json"),
+              Path("tests/proof/solver-results.txt"),
+          )
+          print("solver-bound-proof-receipts: PASS")
+          PY
+
+      - name: Upload generated receipts
+        uses: actions/upload-artifact@v4
+        with:
+          name: solver-bound-proof-receipts
+          path: .build/proof-generated
+          if-no-files-found: error

--- a/.github/workflows/solver-bound-proof-receipts.yml
+++ b/.github/workflows/solver-bound-proof-receipts.yml
@@ -19,11 +19,18 @@ jobs:
       - name: Reject detached solver result paths
         run: python3 scripts/check/check-solver-trust-manifest-boundary.py
 
+      - name: Write and independently validate solver trust receipt
+        run: |
+          python3 scripts/gen/write-solver-trust-boundary-receipt.py
+          python3 scripts/check/check-solver-trust-boundary-receipt.py \
+            .build/proof/solver-trust-boundary.json
+
       - name: Run receipt and result tests
         run: |
           python3 -m unittest \
             scripts.tests.test_solver_receipts \
-            scripts.tests.test_solver_result
+            scripts.tests.test_solver_result \
+            scripts.tests.test_solver_trust_boundary_receipt
 
       - name: Generate complete result from captured solver output
         run: |
@@ -52,5 +59,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: solver-bound-proof-result
-          path: .build/proof-generated
+          path: |
+            .build/proof-generated
+            .build/proof/solver-trust-boundary.json
           if-no-files-found: error

--- a/scripts/check/check-solver-result.py
+++ b/scripts/check/check-solver-result.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Independently validate a complete manifest-carrying solver result."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.solver_result import (  # noqa: E402
+    SolverResultError,
+    validate_solver_result_file,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result", type=Path)
+    parser.add_argument("--subject", type=Path, required=True)
+    parser.add_argument("--solver-input", type=Path, required=True)
+    parser.add_argument("--toolchain", type=Path, required=True)
+    parser.add_argument("--solver-output", type=Path, required=True)
+    parser.add_argument("--trust-manifest", type=Path, required=True)
+    parser.add_argument("--proof-receipt", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        document = validate_solver_result_file(
+            args.result.resolve(),
+            subject_path=args.subject.resolve(),
+            solver_input_path=args.solver_input.resolve(),
+            toolchain_path=args.toolchain.resolve(),
+            solver_output_path=args.solver_output.resolve(),
+            trust_manifest_path=args.trust_manifest.resolve(),
+            proof_receipt_path=args.proof_receipt.resolve(),
+        )
+    except (OSError, ValueError, KeyError, TypeError, SolverResultError) as exc:
+        print(f"solver-result: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "solver-result: PASS: "
+        f"status={document['status']} obligations={document['obligations']['total']} "
+        f"manifest=embedded receipt=embedded"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check/check-solver-trust-boundary-receipt.py
+++ b/scripts/check/check-solver-trust-boundary-receipt.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Independently validate the solver TrustManifest boundary receipt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.solver_trust_boundary_receipt import (  # noqa: E402
+    SolverTrustBoundaryReceiptError,
+    validate_solver_trust_boundary_receipt,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("receipt", type=Path)
+    args = parser.parse_args()
+    try:
+        document = json.loads(args.receipt.read_text(encoding="utf-8"))
+        validated = validate_solver_trust_boundary_receipt(document, root=ROOT)
+    except (OSError, ValueError, json.JSONDecodeError, SolverTrustBoundaryReceiptError) as exc:
+        print(f"solver-trust-boundary-receipt: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "solver-trust-boundary-receipt: PASS: "
+        f"files={len(validated['files'])} primary={validated['primary_result']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check/check-solver-trust-manifest-boundary.py
+++ b/scripts/check/check-solver-trust-manifest-boundary.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Require every public solver result path to emit and validate SolverResult v1."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DRIVER = ROOT / "scripts" / "proof" / "solver_driver.py"
+RESULT = ROOT / "scripts" / "proof" / "solver_result.py"
+RUNNER = ROOT / "scripts" / "run" / "run-proof-solver.py"
+CAPTURED = ROOT / "scripts" / "gen" / "write-solver-receipts.py"
+CHECKER = ROOT / "scripts" / "check" / "check-solver-result.py"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def require(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise ValueError(f"missing {label}: {token}")
+
+
+def _require_result_argument_near_calls(path: Path, command: str) -> None:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        if command not in line:
+            continue
+        window = "\n".join(lines[index : index + 24])
+        if "--solver-result-output" not in window:
+            raise ValueError(
+                f"{path.relative_to(ROOT)}:{index + 1}: {command} lacks --solver-result-output"
+            )
+
+
+def _reject_production_bypasses() -> None:
+    allowed_receipt_generators = {
+        "scripts/proof/solver_driver.py",
+        "scripts/gen/write-solver-receipts.py",
+    }
+    allowed_driver_callers = {
+        "scripts/run/run-proof-solver.py",
+    }
+    violations: list[str] = []
+    for path in sorted((ROOT / "scripts").rglob("*.py")):
+        relative = path.relative_to(ROOT).as_posix()
+        if relative.startswith("scripts/tests/") or relative == "scripts/check/check-solver-trust-manifest-boundary.py":
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "generate_solver_receipts" in text and relative not in allowed_receipt_generators:
+            violations.append(f"{relative}: generates detached TrustManifest/ProofReceipt")
+        if "run_solver_and_generate_receipts" in text and relative not in allowed_driver_callers | {"scripts/proof/solver_driver.py"}:
+            violations.append(f"{relative}: bypasses canonical solver runner")
+    if violations:
+        raise ValueError("\n".join(violations))
+
+
+def main() -> int:
+    for path in (DRIVER, RESULT, RUNNER, CAPTURED, CHECKER):
+        if not path.is_file():
+            raise ValueError(f"solver trust boundary file missing: {path.relative_to(ROOT)}")
+
+    driver = DRIVER.read_text(encoding="utf-8")
+    result = RESULT.read_text(encoding="utf-8")
+    runner = RUNNER.read_text(encoding="utf-8")
+    captured = CAPTURED.read_text(encoding="utf-8")
+
+    for token, label in (
+        ("create_solver_result", "driver result construction"),
+        ("write_solver_result", "driver result write"),
+        ("validate_solver_result_file", "driver independent result validation"),
+        ("solver_result_path", "driver mandatory result path"),
+    ):
+        require(driver, token, label)
+
+    for token, label in (
+        ('SCHEMA = "arukellt-solver-result"', "versioned solver result schema"),
+        ('"trust_manifest"', "embedded TrustManifest"),
+        ('"proof_receipt"', "embedded ProofReceipt"),
+        ('"solver_input_sha256"', "solver input binding"),
+        ('"toolchain_sha256"', "toolchain binding"),
+        ("validate_bound_proof", "external artifact binding"),
+    ):
+        require(result, token, label)
+
+    for text, label in ((runner, "solver runner"), (captured, "captured-output converter")):
+        require(text, '"--solver-result-output"', f"{label} result argument")
+        require(text, "required=True", f"{label} mandatory result argument")
+
+    _reject_production_bypasses()
+    for workflow in sorted((*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml"))):
+        text = workflow.read_text(encoding="utf-8")
+        if "run-proof-solver.py" in text:
+            _require_result_argument_near_calls(workflow, "run-proof-solver.py")
+        if "write-solver-receipts.py" in text:
+            _require_result_argument_near_calls(workflow, "write-solver-receipts.py")
+        if ("run-proof-solver.py" in text or "write-solver-receipts.py" in text) and "solver-result" not in text:
+            raise ValueError(f"{workflow.relative_to(ROOT)}: solver workflow does not retain SolverResult")
+
+    print(
+        "solver-trust-manifest-boundary: PASS: "
+        "every public solver path emits SolverResult v1 with embedded TrustManifest"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"solver-trust-manifest-boundary: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/check/check-solver-trust-manifest-boundary.py
+++ b/scripts/check/check-solver-trust-manifest-boundary.py
@@ -12,6 +12,10 @@ RESULT = ROOT / "scripts" / "proof" / "solver_result.py"
 RUNNER = ROOT / "scripts" / "run" / "run-proof-solver.py"
 CAPTURED = ROOT / "scripts" / "gen" / "write-solver-receipts.py"
 CHECKER = ROOT / "scripts" / "check" / "check-solver-result.py"
+BOUNDARY_GENERATOR = ROOT / "scripts" / "gen" / "write-solver-trust-boundary-receipt.py"
+BOUNDARY_VALIDATOR = ROOT / "scripts" / "proof" / "solver_trust_boundary_receipt.py"
+BOUNDARY_CHECKER = ROOT / "scripts" / "check" / "check-solver-trust-boundary-receipt.py"
+POLICY = ROOT / "release" / "proof-policy.json"
 WORKFLOWS = ROOT / ".github" / "workflows"
 
 
@@ -55,7 +59,18 @@ def _reject_production_bypasses() -> None:
 
 
 def main() -> int:
-    for path in (DRIVER, RESULT, RUNNER, CAPTURED, CHECKER):
+    required_files = (
+        DRIVER,
+        RESULT,
+        RUNNER,
+        CAPTURED,
+        CHECKER,
+        BOUNDARY_GENERATOR,
+        BOUNDARY_VALIDATOR,
+        BOUNDARY_CHECKER,
+        POLICY,
+    )
+    for path in required_files:
         if not path.is_file():
             raise ValueError(f"solver trust boundary file missing: {path.relative_to(ROOT)}")
 
@@ -63,6 +78,9 @@ def main() -> int:
     result = RESULT.read_text(encoding="utf-8")
     runner = RUNNER.read_text(encoding="utf-8")
     captured = CAPTURED.read_text(encoding="utf-8")
+    boundary_generator = BOUNDARY_GENERATOR.read_text(encoding="utf-8")
+    boundary_validator = BOUNDARY_VALIDATOR.read_text(encoding="utf-8")
+    policy = POLICY.read_text(encoding="utf-8")
 
     for token, label in (
         ("create_solver_result", "driver result construction"),
@@ -86,6 +104,20 @@ def main() -> int:
         require(text, '"--solver-result-output"', f"{label} result argument")
         require(text, "required=True", f"{label} mandatory result argument")
 
+    for token, label in (
+        ('"arukellt-solver-trust-boundary"', "boundary receipt schema"),
+        ('"arukellt-solver-result@1"', "primary result identity"),
+        ('"embedded-and-file-bound"', "embedded artifact policy"),
+    ):
+        require(boundary_generator, token, label)
+    for token, label in (
+        ("REQUIRED_CAPABILITIES", "mandatory capability registry"),
+        ("sha256_file(resolved)", "receipt digest verification"),
+        ("duplicate path", "duplicate path rejection"),
+    ):
+        require(boundary_validator, token, label)
+    require(policy, '"solver_trust_manifest": true', "release hard gate")
+
     _reject_production_bypasses()
     for workflow in sorted((*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml"))):
         text = workflow.read_text(encoding="utf-8")
@@ -93,8 +125,16 @@ def main() -> int:
             _require_result_argument_near_calls(workflow, "run-proof-solver.py")
         if "write-solver-receipts.py" in text:
             _require_result_argument_near_calls(workflow, "write-solver-receipts.py")
-        if ("run-proof-solver.py" in text or "write-solver-receipts.py" in text) and "solver-result" not in text:
-            raise ValueError(f"{workflow.relative_to(ROOT)}: solver workflow does not retain SolverResult")
+        if "run-proof-solver.py" in text or "write-solver-receipts.py" in text:
+            if "solver-result" not in text:
+                raise ValueError(f"{workflow.relative_to(ROOT)}: solver workflow does not retain SolverResult")
+            for token in (
+                "write-solver-trust-boundary-receipt.py",
+                "check-solver-trust-boundary-receipt.py",
+                "check-solver-result.py",
+            ):
+                if token not in text:
+                    raise ValueError(f"{workflow.relative_to(ROOT)}: missing solver trust step {token}")
 
     print(
         "solver-trust-manifest-boundary: PASS: "

--- a/scripts/check/check-solver-trust-manifest-boundary.py
+++ b/scripts/check/check-solver-trust-manifest-boundary.py
@@ -38,6 +38,7 @@ def _require_result_argument_near_calls(path: Path, command: str) -> None:
 
 def _reject_production_bypasses() -> None:
     allowed_receipt_generators = {
+        "scripts/proof/solver_receipts.py",
         "scripts/proof/solver_driver.py",
         "scripts/gen/write-solver-receipts.py",
     }

--- a/scripts/gen/write-solver-receipts.py
+++ b/scripts/gen/write-solver-receipts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate SHA-bound TrustManifest and ProofReceipt artifacts."""
+"""Convert captured solver output into a complete manifest-carrying result."""
 
 from __future__ import annotations
 
@@ -13,34 +13,70 @@ if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
 from proof.solver_receipts import generate_solver_receipts  # noqa: E402
+from proof.solver_result import (  # noqa: E402
+    create_solver_result,
+    validate_solver_result_file,
+    write_solver_result,
+)
 
 
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     result.add_argument("--subject", type=Path, required=True)
+    result.add_argument("--solver-input", type=Path, required=True)
     result.add_argument("--solver-output", type=Path, required=True)
     result.add_argument("--toolchain", type=Path, required=True)
     result.add_argument("--trust-manifest-output", type=Path, required=True)
     result.add_argument("--proof-receipt-output", type=Path, required=True)
+    result.add_argument("--solver-result-output", type=Path, required=True)
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
+    subject = args.subject.resolve()
+    solver_input = args.solver_input.resolve()
+    solver_output = args.solver_output.resolve()
+    toolchain = args.toolchain.resolve()
+    manifest_output = args.trust_manifest_output.resolve()
+    receipt_output = args.proof_receipt_output.resolve()
+    result_output = args.solver_result_output.resolve()
     try:
         _, receipt = generate_solver_receipts(
-            args.subject.resolve(),
-            args.solver_output.resolve(),
-            args.toolchain.resolve(),
-            args.trust_manifest_output.resolve(),
-            args.proof_receipt_output.resolve(),
+            subject,
+            solver_output,
+            toolchain,
+            manifest_output,
+            receipt_output,
+        )
+        document = create_solver_result(
+            subject_path=subject,
+            solver_input_path=solver_input,
+            toolchain_path=toolchain,
+            solver_output_path=solver_output,
+            trust_manifest_path=manifest_output,
+            proof_receipt_path=receipt_output,
+            execution_mode="captured-output",
+            process_returncode=None,
+            timed_out=False,
+        )
+        write_solver_result(document, result_output)
+        validate_solver_result_file(
+            result_output,
+            subject_path=subject,
+            solver_input_path=solver_input,
+            toolchain_path=toolchain,
+            solver_output_path=solver_output,
+            trust_manifest_path=manifest_output,
+            proof_receipt_path=receipt_output,
         )
     except (OSError, ValueError, KeyError, TypeError) as exc:
         print(f"write-solver-receipts: FAIL: {exc}", file=sys.stderr)
         return 1
     print(
         "write-solver-receipts: PASS: "
-        f"status={receipt['status']} obligations={receipt['obligations']['total']}"
+        f"status={receipt['status']} obligations={receipt['obligations']['total']} "
+        f"result={result_output}"
     )
     return 0
 

--- a/scripts/gen/write-solver-receipts.py
+++ b/scripts/gen/write-solver-receipts.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Generate SHA-bound TrustManifest and ProofReceipt artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.solver_receipts import generate_solver_receipts  # noqa: E402
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--subject", type=Path, required=True)
+    result.add_argument("--solver-output", type=Path, required=True)
+    result.add_argument("--toolchain", type=Path, required=True)
+    result.add_argument("--trust-manifest-output", type=Path, required=True)
+    result.add_argument("--proof-receipt-output", type=Path, required=True)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        _, receipt = generate_solver_receipts(
+            args.subject.resolve(),
+            args.solver_output.resolve(),
+            args.toolchain.resolve(),
+            args.trust_manifest_output.resolve(),
+            args.proof_receipt_output.resolve(),
+        )
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        print(f"write-solver-receipts: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "write-solver-receipts: PASS: "
+        f"status={receipt['status']} obligations={receipt['obligations']['total']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen/write-solver-trust-boundary-receipt.py
+++ b/scripts/gen/write-solver-trust-boundary-receipt.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Write hash-bound evidence for the manifest-carrying solver result boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.common import sha256_file  # noqa: E402
+from proof.solver_trust_boundary_receipt import (  # noqa: E402
+    REQUIRED_CAPABILITIES,
+    REQUIRED_PRODUCERS,
+    validate_solver_trust_boundary_receipt,
+)
+
+BOUNDARY_FILES = (
+    "scripts/proof/solver_result.py",
+    "scripts/proof/solver_driver.py",
+    "scripts/proof/solver_receipts.py",
+    "scripts/proof/solver_trust_boundary_receipt.py",
+    "scripts/proof/trust.py",
+    "scripts/run/run-proof-solver.py",
+    "scripts/gen/write-solver-receipts.py",
+    "scripts/gen/write-solver-trust-boundary-receipt.py",
+    "scripts/check/check-solver-result.py",
+    "scripts/check/check-solver-trust-manifest-boundary.py",
+    "scripts/check/check-solver-trust-boundary-receipt.py",
+    "scripts/tests/test_solver_receipts.py",
+    "scripts/tests/test_solver_result.py",
+    "scripts/tests/test_solver_driver.py",
+    ".github/workflows/solver-bound-proof-receipts.yml",
+    ".github/workflows/proof-solver-driver.yml",
+    "tests/proof/toolchain/toolchain.json",
+    "release/proof-policy.json",
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "solver-trust-boundary.json",
+    )
+    args = parser.parse_args()
+
+    files: list[dict[str, str]] = []
+    for relative in BOUNDARY_FILES:
+        path = ROOT / relative
+        if not path.is_file():
+            raise ValueError(f"solver trust boundary file missing: {relative}")
+        files.append({"path": relative, "sha256": sha256_file(path)})
+
+    document = {
+        "schema": "arukellt-solver-trust-boundary",
+        "schema_version": 1,
+        "status": "enforced",
+        "primary_result": "arukellt-solver-result@1",
+        "raw_solver_output_role": "evidence-only",
+        "trust_manifest_policy": "embedded-and-file-bound",
+        "proof_receipt_policy": "embedded-and-file-bound",
+        "capabilities": sorted(REQUIRED_CAPABILITIES),
+        "public_producers": sorted(REQUIRED_PRODUCERS),
+        "failure_action": "no-valid-solver-result",
+        "files": files,
+    }
+    validate_solver_trust_boundary_receipt(document, root=ROOT)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        "solver-trust-boundary-receipt: PASS: "
+        f"files={len(files)} output={args.output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"solver-trust-boundary-receipt: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/write-solver-trust-boundary-receipt.py
+++ b/scripts/gen/write-solver-trust-boundary-receipt.py
@@ -34,6 +34,7 @@ BOUNDARY_FILES = (
     "scripts/check/check-solver-trust-boundary-receipt.py",
     "scripts/tests/test_solver_receipts.py",
     "scripts/tests/test_solver_result.py",
+    "scripts/tests/test_solver_trust_boundary_receipt.py",
     "scripts/tests/test_solver_driver.py",
     ".github/workflows/solver-bound-proof-receipts.yml",
     ".github/workflows/proof-solver-driver.yml",

--- a/scripts/proof/solver_driver.py
+++ b/scripts/proof/solver_driver.py
@@ -1,0 +1,148 @@
+"""Run a configured proof solver and generate bound proof artifacts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from proof.solver_receipts import generate_solver_receipts, load_toolchain
+
+
+@dataclass(frozen=True)
+class SolverRunResult:
+    process_returncode: int
+    proof_status: str
+    obligation_count: int
+    solver_output_path: Path
+    trust_manifest_path: Path
+    proof_receipt_path: Path
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label}: expected non-empty string")
+    return value
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{label}: expected positive integer")
+    return value
+
+
+def _solver_executable(toolchain_path: Path, toolchain: dict[str, Any]) -> Path:
+    solver = toolchain.get("solver")
+    if not isinstance(solver, dict):
+        raise ValueError("toolchain.solver: expected object")
+    raw = Path(_string(solver.get("executable"), "toolchain.solver.executable"))
+    if raw.is_absolute() or ".." in raw.parts:
+        raise ValueError("toolchain.solver.executable: expected relative path without '..'")
+    base = toolchain_path.parent.resolve()
+    resolved = (base / raw).resolve()
+    if resolved != base and base not in resolved.parents:
+        raise ValueError("toolchain.solver.executable: resolved path escapes toolchain directory")
+    if not resolved.is_file():
+        raise ValueError(f"toolchain.solver.executable: missing file: {resolved}")
+    if not os.access(resolved, os.X_OK):
+        raise ValueError(f"toolchain.solver.executable: not executable: {resolved}")
+    return resolved
+
+
+def _solver_arguments(toolchain: dict[str, Any]) -> list[str]:
+    solver = toolchain["solver"]
+    raw = solver.get("arguments", [])
+    if not isinstance(raw, list) or any(not isinstance(item, str) for item in raw):
+        raise ValueError("toolchain.solver.arguments: expected string array")
+    return list(raw)
+
+
+def _limit_memory(memory_bytes: int):
+    if os.name != "posix":
+        return None
+
+    def apply() -> None:
+        import resource
+
+        resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+
+    return apply
+
+
+def _captured_output(stdout: str, stderr: str, returncode: int) -> str:
+    lines: list[str] = []
+    lines.extend(line for line in stdout.splitlines() if line.strip())
+    for line in stderr.splitlines():
+        stripped = line.strip()
+        if stripped:
+            lines.append(f"(error stderr: {stripped})")
+    if returncode != 0 and not any(line.strip().lower().startswith("(error") for line in lines):
+        lines.append(f"(error solver exit {returncode})")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def run_solver_and_generate_receipts(
+    subject_path: Path,
+    solver_input_path: Path,
+    toolchain_path: Path,
+    solver_output_path: Path,
+    trust_manifest_path: Path,
+    proof_receipt_path: Path,
+) -> SolverRunResult:
+    toolchain = load_toolchain(toolchain_path)
+    executable = _solver_executable(toolchain_path, toolchain)
+    arguments = _solver_arguments(toolchain)
+    limits = toolchain.get("limits")
+    if not isinstance(limits, dict):
+        raise ValueError("toolchain.limits: expected object")
+    timeout_ms = _positive_int(limits.get("timeout_ms"), "toolchain.limits.timeout_ms")
+    memory_bytes = _positive_int(limits.get("memory_bytes"), "toolchain.limits.memory_bytes")
+    solver_input = solver_input_path.read_text(encoding="utf-8")
+
+    timed_out = False
+    try:
+        completed = subprocess.run(
+            [str(executable), *arguments],
+            input=solver_input,
+            cwd=toolchain_path.parent,
+            capture_output=True,
+            text=True,
+            timeout=timeout_ms / 1000,
+            check=False,
+            preexec_fn=_limit_memory(memory_bytes),
+        )
+        returncode = completed.returncode
+        captured = _captured_output(completed.stdout, completed.stderr, returncode)
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        returncode = 124
+        stdout = exc.stdout.decode() if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = exc.stderr.decode() if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+        captured = _captured_output(stdout, stderr, returncode)
+        captured += "(error solver timeout)\n"
+
+    solver_output_path.parent.mkdir(parents=True, exist_ok=True)
+    solver_output_path.write_text(captured, encoding="utf-8")
+    _, receipt = generate_solver_receipts(
+        subject_path,
+        solver_output_path,
+        toolchain_path,
+        trust_manifest_path,
+        proof_receipt_path,
+    )
+    status = str(receipt["status"])
+    if timed_out and status != "error":
+        raise ValueError("timed-out solver run did not produce status=error")
+    return SolverRunResult(
+        process_returncode=returncode,
+        proof_status=status,
+        obligation_count=int(receipt["obligations"]["total"]),
+        solver_output_path=solver_output_path,
+        trust_manifest_path=trust_manifest_path,
+        proof_receipt_path=proof_receipt_path,
+    )
+
+
+__all__ = ["SolverRunResult", "run_solver_and_generate_receipts"]

--- a/scripts/proof/solver_driver.py
+++ b/scripts/proof/solver_driver.py
@@ -1,4 +1,4 @@
-"""Run a configured proof solver and generate bound proof artifacts."""
+"""Run a configured proof solver and emit one complete solver result artifact."""
 
 from __future__ import annotations
 
@@ -9,6 +9,11 @@ from pathlib import Path
 from typing import Any
 
 from proof.solver_receipts import generate_solver_receipts, load_toolchain
+from proof.solver_result import (
+    create_solver_result,
+    validate_solver_result_file,
+    write_solver_result,
+)
 
 
 @dataclass(frozen=True)
@@ -19,6 +24,7 @@ class SolverRunResult:
     solver_output_path: Path
     trust_manifest_path: Path
     proof_receipt_path: Path
+    solver_result_path: Path
 
 
 def _string(value: Any, label: str) -> str:
@@ -90,6 +96,7 @@ def run_solver_and_generate_receipts(
     solver_output_path: Path,
     trust_manifest_path: Path,
     proof_receipt_path: Path,
+    solver_result_path: Path,
 ) -> SolverRunResult:
     toolchain = load_toolchain(toolchain_path)
     executable = _solver_executable(toolchain_path, toolchain)
@@ -135,6 +142,29 @@ def run_solver_and_generate_receipts(
     status = str(receipt["status"])
     if timed_out and status != "error":
         raise ValueError("timed-out solver run did not produce status=error")
+
+    solver_result = create_solver_result(
+        subject_path=subject_path,
+        solver_input_path=solver_input_path,
+        toolchain_path=toolchain_path,
+        solver_output_path=solver_output_path,
+        trust_manifest_path=trust_manifest_path,
+        proof_receipt_path=proof_receipt_path,
+        execution_mode="solver-process",
+        process_returncode=returncode,
+        timed_out=timed_out,
+    )
+    write_solver_result(solver_result, solver_result_path)
+    validate_solver_result_file(
+        solver_result_path,
+        subject_path=subject_path,
+        solver_input_path=solver_input_path,
+        toolchain_path=toolchain_path,
+        solver_output_path=solver_output_path,
+        trust_manifest_path=trust_manifest_path,
+        proof_receipt_path=proof_receipt_path,
+    )
+
     return SolverRunResult(
         process_returncode=returncode,
         proof_status=status,
@@ -142,6 +172,7 @@ def run_solver_and_generate_receipts(
         solver_output_path=solver_output_path,
         trust_manifest_path=trust_manifest_path,
         proof_receipt_path=proof_receipt_path,
+        solver_result_path=solver_result_path,
     )
 
 

--- a/scripts/proof/solver_receipts.py
+++ b/scripts/proof/solver_receipts.py
@@ -1,0 +1,267 @@
+"""Generate TrustManifest and ProofReceipt artifacts from solver output."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from proof.common import load_json, sha256_file
+from proof.trust import validate_bound_proof, validate_proof_receipt, validate_trust_manifest
+from proof.verified_core import validate_document as validate_verified_core
+
+TOOLCHAIN_SCHEMA = "arukellt-proof-toolchain"
+TOOLCHAIN_VERSION = 1
+
+_STATUS_MAP = {
+    "proved": "proved",
+    "unsat": "proved",
+    "refuted": "refuted",
+    "sat": "refuted",
+    "unknown": "unknown",
+    "error": "error",
+}
+
+
+def _require_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label}: expected object")
+    return value
+
+
+def _require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label}: expected non-empty string")
+    return value
+
+
+def _require_positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{label}: expected positive integer")
+    return value
+
+
+def _exact_keys(value: dict[str, Any], label: str, required: set[str], optional: set[str] = set()) -> None:
+    missing = required - value.keys()
+    if missing:
+        raise ValueError(f"{label}: missing field(s): {', '.join(sorted(missing))}")
+    unknown = value.keys() - required - optional
+    if unknown:
+        raise ValueError(f"{label}: unknown field(s): {', '.join(sorted(unknown))}")
+
+
+def _resolve_file(base: Path, raw: Any, label: str) -> Path:
+    value = _require_string(raw, label)
+    candidate = Path(value)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise ValueError(f"{label}: expected relative path without '..'")
+    resolved = (base / candidate).resolve()
+    if resolved != base and base not in resolved.parents:
+        raise ValueError(f"{label}: resolved path escapes toolchain directory")
+    if not resolved.is_file():
+        raise ValueError(f"{label}: missing file: {resolved}")
+    return resolved
+
+
+def _tool(value: Any, base: Path, label: str) -> dict[str, Any]:
+    tool = _require_object(value, label)
+    _exact_keys(tool, label, {"name", "version", "executable"}, {"arguments", "build_id"})
+    path = _resolve_file(base, tool["executable"], f"{label}.executable")
+    result: dict[str, Any] = {
+        "name": _require_string(tool["name"], f"{label}.name"),
+        "version": _require_string(tool["version"], f"{label}.version"),
+        "executable_sha256": sha256_file(path),
+    }
+    if "build_id" in tool:
+        result["build_id"] = _require_string(tool["build_id"], f"{label}.build_id")
+    if "arguments" in tool:
+        arguments = tool["arguments"]
+        if not isinstance(arguments, list) or any(not isinstance(item, str) for item in arguments):
+            raise ValueError(f"{label}.arguments: expected string array")
+        result["arguments"] = arguments
+    return result
+
+
+def load_toolchain(path: Path) -> dict[str, Any]:
+    value = _require_object(load_json(path), "toolchain")
+    _exact_keys(
+        value,
+        "toolchain",
+        {
+            "schema",
+            "schema_version",
+            "producer",
+            "translator",
+            "solver",
+            "semantic_profile",
+            "assumptions",
+            "trusted_components",
+            "limits",
+        },
+    )
+    if value["schema"] != TOOLCHAIN_SCHEMA:
+        raise ValueError(f"toolchain.schema: expected {TOOLCHAIN_SCHEMA!r}")
+    if value["schema_version"] != TOOLCHAIN_VERSION:
+        raise ValueError(f"toolchain.schema_version: expected {TOOLCHAIN_VERSION}")
+    return value
+
+
+def parse_solver_output(path: Path) -> dict[str, int | str]:
+    counts = {"proved": 0, "refuted": 0, "unknown": 0, "errors": 0}
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith(";") or line == "success":
+            continue
+        token = line
+        if ":" in token:
+            prefix, suffix = token.rsplit(":", 1)
+            if prefix.strip() and suffix.strip():
+                token = suffix.strip()
+        normalized = _STATUS_MAP.get(token.lower())
+        if normalized is None:
+            if token.lower().startswith("(error"):
+                normalized = "error"
+            else:
+                raise ValueError(f"solver output line {line_number}: unsupported result {line!r}")
+        if normalized == "error":
+            counts["errors"] += 1
+        else:
+            counts[normalized] += 1
+    total = counts["proved"] + counts["refuted"] + counts["unknown"] + counts["errors"]
+    if total == 0:
+        raise ValueError("solver output contains no obligations")
+    if counts["errors"]:
+        status = "error"
+    elif counts["refuted"]:
+        status = "refuted"
+    elif counts["unknown"]:
+        status = "unknown"
+    else:
+        status = "proved"
+    return {"total": total, **counts, "status": status}
+
+
+def _subject_ref(subject_path: Path) -> dict[str, Any]:
+    subject = validate_verified_core(load_json(subject_path))
+    return {
+        "schema": subject["schema"],
+        "schema_version": subject["schema_version"],
+        "sha256": sha256_file(subject_path),
+    }
+
+
+def build_trust_manifest(subject_path: Path, toolchain_path: Path) -> dict[str, Any]:
+    toolchain = load_toolchain(toolchain_path)
+    base = toolchain_path.parent.resolve()
+
+    profile = _require_object(toolchain["semantic_profile"], "toolchain.semantic_profile")
+    _exact_keys(profile, "toolchain.semantic_profile", {"integer_model", "overflow", "floating_point", "memory"})
+    semantic_profile = {
+        field: _require_string(profile[field], f"toolchain.semantic_profile.{field}")
+        for field in ("integer_model", "overflow", "floating_point", "memory")
+    }
+
+    assumptions = toolchain["assumptions"]
+    if not isinstance(assumptions, list) or any(not isinstance(item, str) or not item for item in assumptions):
+        raise ValueError("toolchain.assumptions: expected non-empty string array")
+    if len(set(assumptions)) != len(assumptions):
+        raise ValueError("toolchain.assumptions: duplicate assumption")
+
+    components_raw = toolchain["trusted_components"]
+    if not isinstance(components_raw, list) or not components_raw:
+        raise ValueError("toolchain.trusted_components: expected non-empty array")
+    components: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for index, raw in enumerate(components_raw):
+        label = f"toolchain.trusted_components[{index}]"
+        component = _require_object(raw, label)
+        _exact_keys(component, label, {"name", "role", "artifact"}, {"version"})
+        name = _require_string(component["name"], f"{label}.name")
+        role = _require_string(component["role"], f"{label}.role")
+        if (name, role) in seen:
+            raise ValueError(f"{label}: duplicate trusted component")
+        seen.add((name, role))
+        artifact_path = _resolve_file(base, component["artifact"], f"{label}.artifact")
+        rendered: dict[str, Any] = {
+            "name": name,
+            "role": role,
+            "artifact_sha256": sha256_file(artifact_path),
+        }
+        if "version" in component:
+            rendered["version"] = _require_string(component["version"], f"{label}.version")
+        components.append(rendered)
+
+    limits = _require_object(toolchain["limits"], "toolchain.limits")
+    _exact_keys(limits, "toolchain.limits", {"timeout_ms", "memory_bytes"})
+
+    manifest = {
+        "schema": "arukellt-trust-manifest",
+        "schema_version": 1,
+        "subject": _subject_ref(subject_path),
+        "producer": _tool(toolchain["producer"], base, "toolchain.producer"),
+        "translator": _tool(toolchain["translator"], base, "toolchain.translator"),
+        "solver": _tool(toolchain["solver"], base, "toolchain.solver"),
+        "semantic_profile": semantic_profile,
+        "assumptions": assumptions,
+        "trusted_components": components,
+        "limits": {
+            "timeout_ms": _require_positive_int(limits["timeout_ms"], "toolchain.limits.timeout_ms"),
+            "memory_bytes": _require_positive_int(limits["memory_bytes"], "toolchain.limits.memory_bytes"),
+        },
+    }
+    return validate_trust_manifest(manifest)
+
+
+def build_proof_receipt(
+    subject_path: Path,
+    trust_manifest_path: Path,
+    solver_output_path: Path,
+) -> dict[str, Any]:
+    parsed = parse_solver_output(solver_output_path)
+    receipt = {
+        "schema": "arukellt-proof-receipt",
+        "schema_version": 1,
+        "subject": _subject_ref(subject_path),
+        "trust_manifest_sha256": sha256_file(trust_manifest_path),
+        "solver_output_sha256": sha256_file(solver_output_path),
+        "status": parsed["status"],
+        "obligations": {
+            "total": parsed["total"],
+            "proved": parsed["proved"],
+            "refuted": parsed["refuted"],
+            "unknown": parsed["unknown"],
+            "errors": parsed["errors"],
+        },
+    }
+    return validate_proof_receipt(receipt)
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def generate_solver_receipts(
+    subject_path: Path,
+    solver_output_path: Path,
+    toolchain_path: Path,
+    trust_manifest_path: Path,
+    proof_receipt_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    manifest = build_trust_manifest(subject_path, toolchain_path)
+    write_json(trust_manifest_path, manifest)
+    receipt = build_proof_receipt(subject_path, trust_manifest_path, solver_output_path)
+    write_json(proof_receipt_path, receipt)
+    validate_bound_proof(subject_path, trust_manifest_path, proof_receipt_path, solver_output_path)
+    return manifest, receipt
+
+
+__all__ = [
+    "TOOLCHAIN_SCHEMA",
+    "TOOLCHAIN_VERSION",
+    "build_proof_receipt",
+    "build_trust_manifest",
+    "generate_solver_receipts",
+    "load_toolchain",
+    "parse_solver_output",
+]

--- a/scripts/proof/solver_result.py
+++ b/scripts/proof/solver_result.py
@@ -1,0 +1,238 @@
+"""Versioned solver result carrying its TrustManifest and ProofReceipt.
+
+The raw solver stream is evidence, not the primary result.  A valid result
+contains the exact validated TrustManifest and ProofReceipt objects and binds
+them to the subject, solver input, toolchain, and captured output files.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+from proof.common import load_json, sha256_file
+from proof.trust import (
+    validate_bound_proof,
+    validate_proof_receipt,
+    validate_trust_manifest,
+)
+
+SCHEMA = "arukellt-solver-result"
+VERSION = 1
+EXECUTION_MODES = {"solver-process", "captured-output"}
+PROOF_STATUSES = {"proved", "refuted", "unknown", "error"}
+
+
+class SolverResultError(ValueError):
+    """The solver result is malformed, incomplete, or stale."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SolverResultError(message)
+
+
+def _sha256(value: object, path: str) -> str:
+    _require(
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value),
+        f"{path}: expected lowercase SHA-256",
+    )
+    return str(value)
+
+
+def _exact_keys(value: object, expected: set[str], path: str) -> dict[str, Any]:
+    _require(isinstance(value, dict), f"{path}: expected object")
+    document = value
+    _require(set(document) == expected, f"{path}: field set mismatch")
+    return document
+
+
+def _execution(value: object, *, status: str) -> dict[str, Any]:
+    execution = _exact_keys(
+        value,
+        {"mode", "returncode", "timed_out"},
+        "$.execution",
+    )
+    mode = execution["mode"]
+    _require(mode in EXECUTION_MODES, f"$.execution.mode: unsupported mode {mode!r}")
+    _require(type(execution["timed_out"]) is bool, "$.execution.timed_out: expected boolean")
+
+    if mode == "solver-process":
+        returncode = execution["returncode"]
+        _require(type(returncode) is int, "$.execution.returncode: expected integer")
+        if execution["timed_out"]:
+            _require(returncode == 124, "$.execution: timeout must use returncode 124")
+            _require(status == "error", "$.execution: timeout must produce status=error")
+        if returncode != 0:
+            _require(status == "error", "$.execution: nonzero solver exit must produce status=error")
+        if status == "proved":
+            _require(returncode == 0, "$.execution: proved result requires solver exit 0")
+    else:
+        _require(execution["returncode"] is None, "$.execution.returncode: captured output requires null")
+        _require(execution["timed_out"] is False, "$.execution: captured output cannot claim timeout")
+    return execution
+
+
+def validate_solver_result(
+    value: object,
+    *,
+    subject_path: Path,
+    solver_input_path: Path,
+    toolchain_path: Path,
+    solver_output_path: Path,
+    trust_manifest_path: Path,
+    proof_receipt_path: Path,
+) -> dict[str, Any]:
+    document = _exact_keys(
+        value,
+        {
+            "schema",
+            "schema_version",
+            "subject",
+            "toolchain_sha256",
+            "solver_input_sha256",
+            "solver_output_sha256",
+            "execution",
+            "status",
+            "obligations",
+            "trust_manifest",
+            "proof_receipt",
+        },
+        "$",
+    )
+    _require(document["schema"] == SCHEMA, f"$.schema: expected {SCHEMA!r}")
+    _require(document["schema_version"] == VERSION, f"$.schema_version: expected {VERSION}")
+
+    status = document["status"]
+    _require(status in PROOF_STATUSES, f"$.status: unsupported status {status!r}")
+    _execution(document["execution"], status=str(status))
+
+    _, external_manifest, external_receipt = validate_bound_proof(
+        subject_path,
+        trust_manifest_path,
+        proof_receipt_path,
+        solver_output_path,
+    )
+    embedded_manifest = validate_trust_manifest(document["trust_manifest"])
+    embedded_receipt = validate_proof_receipt(document["proof_receipt"])
+    _require(
+        embedded_manifest == external_manifest,
+        "$.trust_manifest: embedded manifest differs from supplied TrustManifest",
+    )
+    _require(
+        embedded_receipt == external_receipt,
+        "$.proof_receipt: embedded receipt differs from supplied ProofReceipt",
+    )
+
+    _require(document["subject"] == external_manifest["subject"], "$.subject: manifest subject mismatch")
+    _require(document["subject"] == external_receipt["subject"], "$.subject: receipt subject mismatch")
+    _require(document["status"] == external_receipt["status"], "$.status: receipt status mismatch")
+    _require(
+        document["obligations"] == external_receipt["obligations"],
+        "$.obligations: receipt obligation counts mismatch",
+    )
+
+    expected_digests = {
+        "toolchain_sha256": sha256_file(toolchain_path),
+        "solver_input_sha256": sha256_file(solver_input_path),
+        "solver_output_sha256": sha256_file(solver_output_path),
+    }
+    for field, expected in expected_digests.items():
+        actual = _sha256(document[field], f"$.{field}")
+        _require(actual == expected, f"$.{field}: digest mismatch")
+    _require(
+        document["solver_output_sha256"] == external_receipt["solver_output_sha256"],
+        "$.solver_output_sha256: ProofReceipt binds another solver output",
+    )
+    return document
+
+
+def create_solver_result(
+    *,
+    subject_path: Path,
+    solver_input_path: Path,
+    toolchain_path: Path,
+    solver_output_path: Path,
+    trust_manifest_path: Path,
+    proof_receipt_path: Path,
+    execution_mode: str,
+    process_returncode: int | None,
+    timed_out: bool,
+) -> dict[str, Any]:
+    _, manifest, receipt = validate_bound_proof(
+        subject_path,
+        trust_manifest_path,
+        proof_receipt_path,
+        solver_output_path,
+    )
+    document = {
+        "schema": SCHEMA,
+        "schema_version": VERSION,
+        "subject": copy.deepcopy(manifest["subject"]),
+        "toolchain_sha256": sha256_file(toolchain_path),
+        "solver_input_sha256": sha256_file(solver_input_path),
+        "solver_output_sha256": sha256_file(solver_output_path),
+        "execution": {
+            "mode": execution_mode,
+            "returncode": process_returncode,
+            "timed_out": timed_out,
+        },
+        "status": receipt["status"],
+        "obligations": copy.deepcopy(receipt["obligations"]),
+        "trust_manifest": copy.deepcopy(manifest),
+        "proof_receipt": copy.deepcopy(receipt),
+    }
+    return validate_solver_result(
+        document,
+        subject_path=subject_path,
+        solver_input_path=solver_input_path,
+        toolchain_path=toolchain_path,
+        solver_output_path=solver_output_path,
+        trust_manifest_path=trust_manifest_path,
+        proof_receipt_path=proof_receipt_path,
+    )
+
+
+def write_solver_result(document: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def validate_solver_result_file(
+    result_path: Path,
+    *,
+    subject_path: Path,
+    solver_input_path: Path,
+    toolchain_path: Path,
+    solver_output_path: Path,
+    trust_manifest_path: Path,
+    proof_receipt_path: Path,
+) -> dict[str, Any]:
+    return validate_solver_result(
+        load_json(result_path),
+        subject_path=subject_path,
+        solver_input_path=solver_input_path,
+        toolchain_path=toolchain_path,
+        solver_output_path=solver_output_path,
+        trust_manifest_path=trust_manifest_path,
+        proof_receipt_path=proof_receipt_path,
+    )
+
+
+__all__ = [
+    "EXECUTION_MODES",
+    "SCHEMA",
+    "VERSION",
+    "SolverResultError",
+    "create_solver_result",
+    "validate_solver_result",
+    "validate_solver_result_file",
+    "write_solver_result",
+]

--- a/scripts/proof/solver_trust_boundary_receipt.py
+++ b/scripts/proof/solver_trust_boundary_receipt.py
@@ -1,0 +1,109 @@
+"""Independent validation for the solver TrustManifest boundary receipt."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from proof.common import sha256_file
+
+SCHEMA = "arukellt-solver-trust-boundary"
+VERSION = 1
+REQUIRED_CAPABILITIES = {
+    "embedded-trust-manifest",
+    "embedded-proof-receipt",
+    "subject-binding",
+    "solver-input-binding",
+    "toolchain-binding",
+    "solver-output-binding",
+    "process-outcome-consistency",
+    "independent-result-validation",
+    "production-bypass-rejection",
+}
+REQUIRED_PRODUCERS = {
+    "scripts/run/run-proof-solver.py",
+    "scripts/gen/write-solver-receipts.py",
+}
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class SolverTrustBoundaryReceiptError(ValueError):
+    """The solver trust boundary receipt is malformed or stale."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SolverTrustBoundaryReceiptError(message)
+
+
+def validate_solver_trust_boundary_receipt(
+    value: object,
+    *,
+    root: Path,
+) -> dict[str, Any]:
+    _require(isinstance(value, dict), "receipt must be an object")
+    receipt = value
+    expected = {
+        "schema",
+        "schema_version",
+        "status",
+        "primary_result",
+        "raw_solver_output_role",
+        "trust_manifest_policy",
+        "proof_receipt_policy",
+        "capabilities",
+        "public_producers",
+        "failure_action",
+        "files",
+    }
+    _require(set(receipt) == expected, "receipt field set mismatch")
+    _require(receipt["schema"] == SCHEMA, f"schema must be {SCHEMA}")
+    _require(receipt["schema_version"] == VERSION, f"schema_version must be {VERSION}")
+    _require(receipt["status"] == "enforced", "status must be enforced")
+    _require(receipt["primary_result"] == "arukellt-solver-result@1", "primary result mismatch")
+    _require(receipt["raw_solver_output_role"] == "evidence-only", "raw output must be evidence-only")
+    _require(receipt["trust_manifest_policy"] == "embedded-and-file-bound", "TrustManifest policy mismatch")
+    _require(receipt["proof_receipt_policy"] == "embedded-and-file-bound", "ProofReceipt policy mismatch")
+    _require(receipt["failure_action"] == "no-valid-solver-result", "failure action mismatch")
+
+    capabilities = receipt["capabilities"]
+    _require(isinstance(capabilities, list), "capabilities must be an array")
+    _require(set(capabilities) == REQUIRED_CAPABILITIES, "capability set mismatch")
+    _require(len(capabilities) == len(REQUIRED_CAPABILITIES), "duplicate capability")
+
+    producers = receipt["public_producers"]
+    _require(isinstance(producers, list), "public_producers must be an array")
+    _require(set(producers) == REQUIRED_PRODUCERS, "public producer set mismatch")
+    _require(len(producers) == len(REQUIRED_PRODUCERS), "duplicate public producer")
+
+    files = receipt["files"]
+    _require(isinstance(files, list) and files, "files must be a non-empty array")
+    seen: set[str] = set()
+    resolved_root = root.resolve()
+    for index, raw in enumerate(files):
+        _require(isinstance(raw, dict), f"files[{index}] must be an object")
+        _require(set(raw) == {"path", "sha256"}, f"files[{index}] field set mismatch")
+        relative = raw["path"]
+        digest = raw["sha256"]
+        _require(isinstance(relative, str) and relative, f"files[{index}].path invalid")
+        path_value = Path(relative)
+        _require(not path_value.is_absolute() and ".." not in path_value.parts, f"files[{index}].path escapes root")
+        _require(relative not in seen, f"duplicate path: {relative}")
+        seen.add(relative)
+        _require(isinstance(digest, str) and _SHA256.fullmatch(digest) is not None, f"files[{index}].sha256 invalid")
+        resolved = (resolved_root / path_value).resolve()
+        _require(resolved == resolved_root or resolved_root in resolved.parents, f"files[{index}].path escapes root")
+        _require(resolved.is_file(), f"receipt file missing: {relative}")
+        _require(sha256_file(resolved) == digest, f"receipt digest mismatch: {relative}")
+    return receipt
+
+
+__all__ = [
+    "REQUIRED_CAPABILITIES",
+    "REQUIRED_PRODUCERS",
+    "SCHEMA",
+    "VERSION",
+    "SolverTrustBoundaryReceiptError",
+    "validate_solver_trust_boundary_receipt",
+]

--- a/scripts/run/run-proof-solver.py
+++ b/scripts/run/run-proof-solver.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run a configured solver and emit SHA-bound proof artifacts."""
+"""Run a configured solver and emit a manifest-carrying solver result."""
 
 from __future__ import annotations
 
@@ -23,6 +23,7 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--solver-output", type=Path, required=True)
     result.add_argument("--trust-manifest-output", type=Path, required=True)
     result.add_argument("--proof-receipt-output", type=Path, required=True)
+    result.add_argument("--solver-result-output", type=Path, required=True)
     return result
 
 
@@ -36,6 +37,7 @@ def main() -> int:
             args.solver_output.resolve(),
             args.trust_manifest_output.resolve(),
             args.proof_receipt_output.resolve(),
+            args.solver_result_output.resolve(),
         )
     except (OSError, ValueError, KeyError, TypeError) as exc:
         print(f"run-proof-solver: FAIL: {exc}", file=sys.stderr)
@@ -43,7 +45,7 @@ def main() -> int:
     print(
         "run-proof-solver: "
         f"status={result.proof_status} obligations={result.obligation_count} "
-        f"solver_exit={result.process_returncode}"
+        f"solver_exit={result.process_returncode} result={result.solver_result_path}"
     )
     if result.process_returncode != 0 or result.proof_status != "proved":
         return 2

--- a/scripts/run/run-proof-solver.py
+++ b/scripts/run/run-proof-solver.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Run a configured solver and emit SHA-bound proof artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.solver_driver import run_solver_and_generate_receipts  # noqa: E402
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--subject", type=Path, required=True)
+    result.add_argument("--solver-input", type=Path, required=True)
+    result.add_argument("--toolchain", type=Path, required=True)
+    result.add_argument("--solver-output", type=Path, required=True)
+    result.add_argument("--trust-manifest-output", type=Path, required=True)
+    result.add_argument("--proof-receipt-output", type=Path, required=True)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        result = run_solver_and_generate_receipts(
+            args.subject.resolve(),
+            args.solver_input.resolve(),
+            args.toolchain.resolve(),
+            args.solver_output.resolve(),
+            args.trust_manifest_output.resolve(),
+            args.proof_receipt_output.resolve(),
+        )
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        print(f"run-proof-solver: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "run-proof-solver: "
+        f"status={result.proof_status} obligations={result.obligation_count} "
+        f"solver_exit={result.process_returncode}"
+    )
+    if result.process_returncode != 0 or result.proof_status != "proved":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_solver_driver.py
+++ b/scripts/tests/test_solver_driver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import stat
 import sys
 import tempfile
@@ -14,6 +13,7 @@ if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
 from proof.solver_driver import run_solver_and_generate_receipts  # noqa: E402
+from proof.solver_result import validate_solver_result_file  # noqa: E402
 from proof.trust import validate_bound_proof  # noqa: E402
 
 
@@ -36,6 +36,7 @@ class SolverDriverTests(unittest.TestCase):
         output_path = root / "solver-output.txt"
         manifest_path = root / "trust-manifest.json"
         receipt_path = root / "proof-receipt.json"
+        result_path = root / "solver-result.json"
         result = run_solver_and_generate_receipts(
             self.subject,
             input_path,
@@ -43,38 +44,72 @@ class SolverDriverTests(unittest.TestCase):
             output_path,
             manifest_path,
             receipt_path,
+            result_path,
         )
-        return result, output_path, manifest_path, receipt_path
+        return result, input_path, output_path, manifest_path, receipt_path, result_path
+
+    def validate_result(
+        self,
+        input_path: Path,
+        output_path: Path,
+        manifest_path: Path,
+        receipt_path: Path,
+        result_path: Path,
+    ) -> dict[str, object]:
+        return validate_solver_result_file(
+            result_path,
+            subject_path=self.subject,
+            solver_input_path=input_path,
+            toolchain_path=self.toolchain,
+            solver_output_path=output_path,
+            trust_manifest_path=manifest_path,
+            proof_receipt_path=receipt_path,
+        )
 
     def test_proved_solver_run_is_bound(self) -> None:
-        result, output, manifest, receipt = self.run_fixture("prove\n")
+        result, input_path, output, manifest, receipt, solver_result = self.run_fixture("prove\n")
         self.assertEqual(result.process_returncode, 0)
         self.assertEqual(result.proof_status, "proved")
+        self.assertEqual(result.solver_result_path, solver_result)
         self.assertEqual(output.read_text(encoding="utf-8"), "unsat\n")
         validate_bound_proof(self.subject, manifest, receipt, output)
+        document = self.validate_result(input_path, output, manifest, receipt, solver_result)
+        self.assertEqual(document["execution"], {
+            "mode": "solver-process",
+            "returncode": 0,
+            "timed_out": False,
+        })
+        self.assertEqual(document["trust_manifest"], json.loads(manifest.read_text()))
+        self.assertEqual(document["proof_receipt"], json.loads(receipt.read_text()))
 
     def test_unknown_is_not_promoted_to_proved(self) -> None:
-        result, output, _, receipt = self.run_fixture("not-modelled\n")
-        document = json.loads(receipt.read_text(encoding="utf-8"))
+        result, input_path, output, manifest, receipt, solver_result = self.run_fixture("not-modelled\n")
+        receipt_document = json.loads(receipt.read_text(encoding="utf-8"))
         self.assertEqual(result.process_returncode, 0)
         self.assertEqual(result.proof_status, "unknown")
-        self.assertEqual(document["obligations"]["unknown"], 1)
+        self.assertEqual(receipt_document["obligations"]["unknown"], 1)
         self.assertEqual(output.read_text(encoding="utf-8"), "unknown\n")
+        result_document = self.validate_result(input_path, output, manifest, receipt, solver_result)
+        self.assertEqual(result_document["status"], "unknown")
 
-    def test_nonzero_solver_exit_produces_error_receipt(self) -> None:
-        result, output, _, receipt = self.run_fixture("error\n")
-        document = json.loads(receipt.read_text(encoding="utf-8"))
+    def test_nonzero_solver_exit_produces_error_result(self) -> None:
+        result, input_path, output, manifest, receipt, solver_result = self.run_fixture("error\n")
+        receipt_document = json.loads(receipt.read_text(encoding="utf-8"))
         self.assertEqual(result.process_returncode, 2)
         self.assertEqual(result.proof_status, "error")
-        self.assertEqual(document["obligations"]["errors"], 1)
+        self.assertEqual(receipt_document["obligations"]["errors"], 1)
         self.assertIn("(error simulated)", output.read_text(encoding="utf-8"))
+        result_document = self.validate_result(input_path, output, manifest, receipt, solver_result)
+        self.assertEqual(result_document["execution"]["returncode"], 2)
+        self.assertEqual(result_document["status"], "error")
 
-    def test_non_executable_solver_is_rejected(self) -> None:
+    def test_non_executable_solver_is_rejected_without_result(self) -> None:
         self.solver.chmod(self.original_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH)
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             input_path = root / "input.smt2"
             input_path.write_text("prove\n", encoding="utf-8")
+            result_path = root / "solver-result.json"
             with self.assertRaisesRegex(ValueError, "not executable"):
                 run_solver_and_generate_receipts(
                     self.subject,
@@ -83,7 +118,9 @@ class SolverDriverTests(unittest.TestCase):
                     root / "solver-output.txt",
                     root / "trust-manifest.json",
                     root / "proof-receipt.json",
+                    result_path,
                 )
+            self.assertFalse(result_path.exists())
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_solver_driver.py
+++ b/scripts/tests/test_solver_driver.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.solver_driver import run_solver_and_generate_receipts  # noqa: E402
+from proof.trust import validate_bound_proof  # noqa: E402
+
+
+class SolverDriverTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proof_dir = ROOT / "tests" / "proof"
+        self.subject = self.proof_dir / "verified-core.json"
+        self.toolchain = self.proof_dir / "toolchain" / "toolchain.json"
+        self.solver = self.proof_dir / "toolchain" / "fake_solver.py"
+        self.original_mode = stat.S_IMODE(self.solver.stat().st_mode)
+        self.solver.chmod(self.original_mode | stat.S_IXUSR)
+        self.addCleanup(self.solver.chmod, self.original_mode)
+
+    def run_fixture(self, solver_input: str):
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        input_path = root / "input.smt2"
+        input_path.write_text(solver_input, encoding="utf-8")
+        output_path = root / "solver-output.txt"
+        manifest_path = root / "trust-manifest.json"
+        receipt_path = root / "proof-receipt.json"
+        result = run_solver_and_generate_receipts(
+            self.subject,
+            input_path,
+            self.toolchain,
+            output_path,
+            manifest_path,
+            receipt_path,
+        )
+        return result, output_path, manifest_path, receipt_path
+
+    def test_proved_solver_run_is_bound(self) -> None:
+        result, output, manifest, receipt = self.run_fixture("prove\n")
+        self.assertEqual(result.process_returncode, 0)
+        self.assertEqual(result.proof_status, "proved")
+        self.assertEqual(output.read_text(encoding="utf-8"), "unsat\n")
+        validate_bound_proof(self.subject, manifest, receipt, output)
+
+    def test_unknown_is_not_promoted_to_proved(self) -> None:
+        result, output, _, receipt = self.run_fixture("not-modelled\n")
+        document = json.loads(receipt.read_text(encoding="utf-8"))
+        self.assertEqual(result.process_returncode, 0)
+        self.assertEqual(result.proof_status, "unknown")
+        self.assertEqual(document["obligations"]["unknown"], 1)
+        self.assertEqual(output.read_text(encoding="utf-8"), "unknown\n")
+
+    def test_nonzero_solver_exit_produces_error_receipt(self) -> None:
+        result, output, _, receipt = self.run_fixture("error\n")
+        document = json.loads(receipt.read_text(encoding="utf-8"))
+        self.assertEqual(result.process_returncode, 2)
+        self.assertEqual(result.proof_status, "error")
+        self.assertEqual(document["obligations"]["errors"], 1)
+        self.assertIn("(error simulated)", output.read_text(encoding="utf-8"))
+
+    def test_non_executable_solver_is_rejected(self) -> None:
+        self.solver.chmod(self.original_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            input_path = root / "input.smt2"
+            input_path.write_text("prove\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "not executable"):
+                run_solver_and_generate_receipts(
+                    self.subject,
+                    input_path,
+                    self.toolchain,
+                    root / "solver-output.txt",
+                    root / "trust-manifest.json",
+                    root / "proof-receipt.json",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_solver_receipts.py
+++ b/scripts/tests/test_solver_receipts.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.common import ValidationError, sha256_file  # noqa: E402
+from proof.solver_receipts import generate_solver_receipts, parse_solver_output  # noqa: E402
+from proof.trust import validate_bound_proof  # noqa: E402
+
+
+class SolverReceiptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proof_dir = ROOT / "tests" / "proof"
+        self.subject = self.proof_dir / "verified-core.json"
+        self.solver_output = self.proof_dir / "solver-results.txt"
+        self.toolchain = self.proof_dir / "toolchain" / "toolchain.json"
+
+    def test_parse_raw_solver_results(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "solver.txt"
+            path.write_text("unsat\nsat\nunknown\n(error bad)\n", encoding="utf-8")
+            parsed = parse_solver_output(path)
+        self.assertEqual(parsed["total"], 4)
+        self.assertEqual(parsed["proved"], 1)
+        self.assertEqual(parsed["refuted"], 1)
+        self.assertEqual(parsed["unknown"], 1)
+        self.assertEqual(parsed["errors"], 1)
+        self.assertEqual(parsed["status"], "error")
+
+    def test_unknown_solver_line_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "solver.txt"
+            path.write_text("probably-unsat\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "unsupported result"):
+                parse_solver_output(path)
+
+    def test_generate_bound_proved_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest_path = root / "trust-manifest.json"
+            receipt_path = root / "proof-receipt.json"
+            manifest, receipt = generate_solver_receipts(
+                self.subject,
+                self.solver_output,
+                self.toolchain,
+                manifest_path,
+                receipt_path,
+            )
+            validate_bound_proof(
+                self.subject,
+                manifest_path,
+                receipt_path,
+                self.solver_output,
+            )
+            toolchain = json.loads(self.toolchain.read_text(encoding="utf-8"))
+            solver_path = self.toolchain.parent / toolchain["solver"]["executable"]
+            self.assertEqual(manifest["solver"]["executable_sha256"], sha256_file(solver_path))
+            self.assertEqual(receipt["status"], "proved")
+            self.assertEqual(receipt["obligations"]["proved"], 1)
+
+    def test_modified_solver_output_invalidates_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output_copy = root / "solver-results.txt"
+            output_copy.write_text(self.solver_output.read_text(encoding="utf-8"), encoding="utf-8")
+            manifest_path = root / "trust-manifest.json"
+            receipt_path = root / "proof-receipt.json"
+            generate_solver_receipts(
+                self.subject,
+                output_copy,
+                self.toolchain,
+                manifest_path,
+                receipt_path,
+            )
+            output_copy.write_text("sat\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValidationError, "does not bind the supplied solver output"):
+                validate_bound_proof(
+                    self.subject,
+                    manifest_path,
+                    receipt_path,
+                    output_copy,
+                )
+
+    def test_empty_solver_output_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "solver.txt"
+            path.write_text("; no result\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "no obligations"):
+                parse_solver_output(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_solver_result.py
+++ b/scripts/tests/test_solver_result.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.solver_receipts import generate_solver_receipts  # noqa: E402
+from proof.solver_result import (  # noqa: E402
+    SolverResultError,
+    create_solver_result,
+    validate_solver_result,
+    validate_solver_result_file,
+    write_solver_result,
+)
+
+
+class SolverResultTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        proof = ROOT / "tests" / "proof"
+        self.subject = proof / "verified-core.json"
+        self.toolchain = proof / "toolchain" / "toolchain.json"
+        self.input = self.root / "solver-input.smt2"
+        self.input.write_text((proof / "solver-input.smt2").read_text(), encoding="utf-8")
+        self.output = self.root / "solver-output.txt"
+        self.output.write_text((proof / "solver-results.txt").read_text(), encoding="utf-8")
+        self.manifest = self.root / "trust-manifest.json"
+        self.receipt = self.root / "proof-receipt.json"
+        generate_solver_receipts(
+            self.subject,
+            self.output,
+            self.toolchain,
+            self.manifest,
+            self.receipt,
+        )
+        self.document = create_solver_result(
+            subject_path=self.subject,
+            solver_input_path=self.input,
+            toolchain_path=self.toolchain,
+            solver_output_path=self.output,
+            trust_manifest_path=self.manifest,
+            proof_receipt_path=self.receipt,
+            execution_mode="captured-output",
+            process_returncode=None,
+            timed_out=False,
+        )
+        self.result = self.root / "solver-result.json"
+        write_solver_result(self.document, self.result)
+
+    def validate(self, document: object | None = None):
+        if document is None:
+            return validate_solver_result_file(
+                self.result,
+                subject_path=self.subject,
+                solver_input_path=self.input,
+                toolchain_path=self.toolchain,
+                solver_output_path=self.output,
+                trust_manifest_path=self.manifest,
+                proof_receipt_path=self.receipt,
+            )
+        return validate_solver_result(
+            document,
+            subject_path=self.subject,
+            solver_input_path=self.input,
+            toolchain_path=self.toolchain,
+            solver_output_path=self.output,
+            trust_manifest_path=self.manifest,
+            proof_receipt_path=self.receipt,
+        )
+
+    def test_complete_result_carries_manifest_and_receipt(self) -> None:
+        validated = self.validate()
+        self.assertEqual(validated["schema"], "arukellt-solver-result")
+        self.assertEqual(validated["schema_version"], 1)
+        self.assertEqual(validated["status"], "proved")
+        self.assertEqual(validated["trust_manifest"], json.loads(self.manifest.read_text()))
+        self.assertEqual(validated["proof_receipt"], json.loads(self.receipt.read_text()))
+
+    def test_stale_solver_input_is_rejected(self) -> None:
+        self.input.write_text("changed input\n", encoding="utf-8")
+        with self.assertRaisesRegex(SolverResultError, "solver_input_sha256: digest mismatch"):
+            self.validate()
+
+    def test_stale_solver_output_is_rejected(self) -> None:
+        self.output.write_text("sat\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "solver output"):
+            self.validate()
+
+    def test_stale_toolchain_is_rejected(self) -> None:
+        copied = self.root / "toolchain.json"
+        copied.write_text(self.toolchain.read_text(), encoding="utf-8")
+        document = copy.deepcopy(self.document)
+        with self.assertRaisesRegex(SolverResultError, "toolchain_sha256: digest mismatch"):
+            validate_solver_result(
+                document,
+                subject_path=self.subject,
+                solver_input_path=self.input,
+                toolchain_path=copied,
+                solver_output_path=self.output,
+                trust_manifest_path=self.manifest,
+                proof_receipt_path=self.receipt,
+            )
+
+    def test_embedded_manifest_substitution_is_rejected(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["trust_manifest"]["solver"]["version"] = "substituted"
+        with self.assertRaisesRegex(SolverResultError, "embedded manifest differs"):
+            self.validate(document)
+
+    def test_embedded_receipt_substitution_is_rejected(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["proof_receipt"]["obligations"]["proved"] = 0
+        document["proof_receipt"]["obligations"]["unknown"] = 1
+        document["proof_receipt"]["status"] = "unknown"
+        with self.assertRaisesRegex(SolverResultError, "embedded receipt differs"):
+            self.validate(document)
+
+    def test_top_level_status_cannot_disagree_with_receipt(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["status"] = "unknown"
+        with self.assertRaisesRegex(SolverResultError, "receipt status mismatch"):
+            self.validate(document)
+
+    def test_proved_process_result_requires_zero_exit(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["execution"] = {
+            "mode": "solver-process",
+            "returncode": 2,
+            "timed_out": False,
+        }
+        with self.assertRaisesRegex(SolverResultError, "nonzero solver exit"):
+            self.validate(document)
+
+    def test_captured_output_cannot_claim_process_exit(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["execution"]["returncode"] = 0
+        with self.assertRaisesRegex(SolverResultError, "captured output requires null"):
+            self.validate(document)
+
+    def test_missing_manifest_field_is_rejected(self) -> None:
+        document = copy.deepcopy(self.document)
+        del document["trust_manifest"]
+        with self.assertRaisesRegex(SolverResultError, "field set mismatch"):
+            self.validate(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_solver_result.py
+++ b/scripts/tests/test_solver_result.py
@@ -98,7 +98,7 @@ class SolverResultTests(unittest.TestCase):
 
     def test_stale_toolchain_is_rejected(self) -> None:
         copied = self.root / "toolchain.json"
-        copied.write_text(self.toolchain.read_text(), encoding="utf-8")
+        copied.write_text(self.toolchain.read_text() + "\n", encoding="utf-8")
         document = copy.deepcopy(self.document)
         with self.assertRaisesRegex(SolverResultError, "toolchain_sha256: digest mismatch"):
             validate_solver_result(

--- a/scripts/tests/test_solver_trust_boundary_receipt.py
+++ b/scripts/tests/test_solver_trust_boundary_receipt.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.solver_trust_boundary_receipt import (  # noqa: E402
+    REQUIRED_CAPABILITIES,
+    REQUIRED_PRODUCERS,
+    SolverTrustBoundaryReceiptError,
+    validate_solver_trust_boundary_receipt,
+)
+
+
+class SolverTrustBoundaryReceiptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.boundary = self.root / "boundary.py"
+        self.boundary.write_text("boundary\n", encoding="utf-8")
+        digest = hashlib.sha256(self.boundary.read_bytes()).hexdigest()
+        self.document = {
+            "schema": "arukellt-solver-trust-boundary",
+            "schema_version": 1,
+            "status": "enforced",
+            "primary_result": "arukellt-solver-result@1",
+            "raw_solver_output_role": "evidence-only",
+            "trust_manifest_policy": "embedded-and-file-bound",
+            "proof_receipt_policy": "embedded-and-file-bound",
+            "capabilities": sorted(REQUIRED_CAPABILITIES),
+            "public_producers": sorted(REQUIRED_PRODUCERS),
+            "failure_action": "no-valid-solver-result",
+            "files": [{"path": "boundary.py", "sha256": digest}],
+        }
+
+    def validate(self, document: object | None = None):
+        return validate_solver_trust_boundary_receipt(
+            self.document if document is None else document,
+            root=self.root,
+        )
+
+    def test_accepts_complete_receipt(self) -> None:
+        self.assertEqual(self.validate()["status"], "enforced")
+
+    def test_stale_file_is_rejected(self) -> None:
+        self.boundary.write_text("changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(SolverTrustBoundaryReceiptError, "digest mismatch"):
+            self.validate()
+
+    def test_missing_capability_is_rejected(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["capabilities"].pop()
+        with self.assertRaisesRegex(SolverTrustBoundaryReceiptError, "capability set mismatch"):
+            self.validate(document)
+
+    def test_duplicate_path_is_rejected(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["files"].append(copy.deepcopy(document["files"][0]))
+        with self.assertRaisesRegex(SolverTrustBoundaryReceiptError, "duplicate path"):
+            self.validate(document)
+
+    def test_detached_manifest_policy_is_rejected(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["trust_manifest_policy"] = "external-only"
+        with self.assertRaisesRegex(SolverTrustBoundaryReceiptError, "TrustManifest policy mismatch"):
+            self.validate(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/proof/solver-input.smt2
+++ b/tests/proof/solver-input.smt2
@@ -1,0 +1,2 @@
+; prove fixture
+prove

--- a/tests/proof/solver-results.txt
+++ b/tests/proof/solver-results.txt
@@ -1,0 +1,2 @@
+; one verification condition
+unsat

--- a/tests/proof/toolchain/fake_solver.py
+++ b/tests/proof/toolchain/fake_solver.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+
+source = sys.stdin.read()
+if "prove" in source:
+    print("unsat")
+elif "refute" in source:
+    print("sat")
+elif "error" in source:
+    print("(error simulated)")
+    raise SystemExit(2)
+else:
+    print("unknown")

--- a/tests/proof/toolchain/producer.bin
+++ b/tests/proof/toolchain/producer.bin
@@ -1,0 +1,1 @@
+arukellt producer fixture

--- a/tests/proof/toolchain/solver.txt
+++ b/tests/proof/toolchain/solver.txt
@@ -1,0 +1,1 @@
+z3 solver fixture

--- a/tests/proof/toolchain/toolchain.json
+++ b/tests/proof/toolchain/toolchain.json
@@ -1,0 +1,39 @@
+{
+  "schema": "arukellt-proof-toolchain",
+  "schema_version": 1,
+  "producer": {
+    "name": "arukellt",
+    "version": "fixture",
+    "executable": "producer.bin"
+  },
+  "translator": {
+    "name": "arukellt-why3",
+    "version": "fixture",
+    "executable": "translator.txt"
+  },
+  "solver": {
+    "name": "z3",
+    "version": "fixture",
+    "executable": "solver.txt",
+    "arguments": ["-in", "-smt2"]
+  },
+  "semantic_profile": {
+    "integer_model": "mathematical",
+    "overflow": "checked",
+    "floating_point": "unsupported",
+    "memory": "pure-values"
+  },
+  "assumptions": [],
+  "trusted_components": [
+    {
+      "name": "arukellt-verified-core-v1",
+      "role": "artifact-validator",
+      "version": "1",
+      "artifact": "trusted-component.txt"
+    }
+  ],
+  "limits": {
+    "timeout_ms": 10000,
+    "memory_bytes": 1073741824
+  }
+}

--- a/tests/proof/toolchain/toolchain.json
+++ b/tests/proof/toolchain/toolchain.json
@@ -14,8 +14,8 @@
   "solver": {
     "name": "z3",
     "version": "fixture",
-    "executable": "solver.txt",
-    "arguments": ["-in", "-smt2"]
+    "executable": "fake_solver.py",
+    "arguments": []
   },
   "semantic_profile": {
     "integer_model": "mathematical",

--- a/tests/proof/toolchain/translator.txt
+++ b/tests/proof/toolchain/translator.txt
@@ -1,0 +1,1 @@
+arukellt why3 translator fixture

--- a/tests/proof/toolchain/trusted-component.txt
+++ b/tests/proof/toolchain/trusted-component.txt
@@ -1,0 +1,1 @@
+verified-core-v1 validator fixture


### PR DESCRIPTION
## Completed acceptance

Every public solver path now emits `arukellt-solver-result` v1 as its primary result. The artifact carries the complete validated TrustManifest and ProofReceipt instead of treating raw solver stdout as a standalone result.

## SolverResult v1

A solver result contains and binds:

- proof subject identity and SHA-256
- exact proof toolchain file SHA-256
- exact solver input SHA-256
- exact captured solver output SHA-256
- execution mode, process return code, and timeout state
- proof status and obligation counts
- the complete `arukellt-trust-manifest` v1 object
- the complete `arukellt-proof-receipt` v1 object

The embedded Manifest and Receipt must exactly equal the independently written files. The Receipt must bind the supplied Manifest, subject, and solver output. Top-level status and obligation counts must equal the Receipt.

## Execution consistency

For real process runs:

- a timeout requires return code 124 and `status=error`
- every nonzero solver exit requires `status=error`
- `status=proved` requires solver exit 0
- `unknown` and `refuted` remain non-success CLI outcomes

Captured-output conversion is explicitly marked `mode=captured-output` and cannot claim a process return code or timeout.

## Mandatory producers

Both public producers require `--solver-result-output`:

- `scripts/run/run-proof-solver.py`
- `scripts/gen/write-solver-receipts.py`

The process driver and captured-output converter both construct, write, and independently revalidate SolverResult v1. A pre-execution failure does not create a result artifact.

## Independent validation

- `scripts/proof/solver_result.py` is the schema and validator
- `scripts/check/check-solver-result.py` independently revalidates the result against the subject, input, toolchain, output, Manifest, and Receipt
- CI validates proved, unknown, and process-error result artifacts

## Bypass prevention

`check-solver-trust-manifest-boundary.py` scans production scripts and workflows. It rejects:

- detached TrustManifest/ProofReceipt generation outside the two approved producers and implementation module
- direct solver-driver use outside the canonical CLI
- solver commands without `--solver-result-output`
- workflows that retain raw output but not SolverResult
- workflows that omit independent result and boundary-receipt validation

Raw solver output is classified as evidence-only, never the primary result.

## Versioned boundary evidence

`write-solver-trust-boundary-receipt.py` emits `arukellt-solver-trust-boundary` v1. It hash-binds the result schema, driver, receipt generation, validators, CLIs, workflows, tests, toolchain fixture, and proof policy.

An independent receipt validator checks:

- schema and policy identity
- mandatory capability and producer sets
- repository-relative unique paths
- every file SHA-256

`release/proof-policy.json` retains `solver_trust_manifest=true`.

## Negative coverage

Tests reject stale solver input, output, or toolchain; substituted embedded Manifest or Receipt; top-level status disagreement; nonzero proved process exits; captured output claiming process metadata; missing Manifest fields; stale boundary files; incomplete capability sets; duplicate receipt paths; and detached-Manifest policy.

## Stack integration

Downstream #27–#34 branches must rebase and add `--solver-result-output` to their solver invocations. Missing output fails closed rather than falling back to detached artifacts.

## Validation commands

- `python3 scripts/check/check-solver-trust-manifest-boundary.py`
- `python3 -m unittest scripts.tests.test_solver_receipts scripts.tests.test_solver_result scripts.tests.test_solver_trust_boundary_receipt scripts.tests.test_solver_driver`
- `python3 scripts/gen/write-solver-trust-boundary-receipt.py`
- `python3 scripts/check/check-solver-trust-boundary-receipt.py .build/proof/solver-trust-boundary.json`

CI status is not claimed here. Completion refers to the implementation, fail-closed artifact boundary, independent validators, evidence receipt, negative tests, and review surface.