### PR TITLE
feat(proof): generate SMT VCs from VerifiedCore

### DIFF
--- a/.github/workflows/z3-proof-run.yml
+++ b/.github/workflows/z3-proof-run.yml
@@ -2,7 +2,7 @@ name: Z3 proof run
 
 on:
   pull_request:
-    branches: [agent/proof-solver-driver, agent/solver-bound-proof-receipts, agent/formal-verification-hard-gates, master]
+    branches: [agent/z3-proof-run, agent/proof-solver-driver, agent/solver-bound-proof-receipts, agent/formal-verification-hard-gates, master]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/z3-proof-run.yml
+++ b/.github/workflows/z3-proof-run.yml
@@ -16,18 +16,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Test VerifiedCore SMT adapter
+        run: python3 -m unittest scripts.tests.test_smtlib_v1
+
       - name: Install Z3
         run: |
           sudo apt-get update
           sudo apt-get install -y z3
           z3 --version
 
+      - name: Generate verification conditions from VerifiedCore
+        run: |
+          mkdir -p .build/z3-proof
+          python3 scripts/gen/write-smt-vcs.py \
+            --subject tests/proof/verified-core.json \
+            --output .build/z3-proof/verified-core-vcs.smt2
+          grep -q '(check-sat)' .build/z3-proof/verified-core-vcs.smt2
+
       - name: Build hash-bound toolchain bundle
         run: |
           mkdir -p .build/z3-toolchain
           cp "$(command -v z3)" .build/z3-toolchain/z3
           cp tests/proof/toolchain/producer.bin .build/z3-toolchain/producer.bin
-          cp tests/proof/toolchain/translator.txt .build/z3-toolchain/translator.txt
+          cp scripts/proof/smtlib_v1.py .build/z3-toolchain/smtlib_v1.py
           cp tests/proof/toolchain/trusted-component.txt .build/z3-toolchain/trusted-component.txt
           python3 - <<'PY'
           import json
@@ -44,9 +55,9 @@ jobs:
                   "executable": "producer.bin",
               },
               "translator": {
-                  "name": "arukellt-smtlib",
-                  "version": "identity-vc-v1",
-                  "executable": "translator.txt",
+                  "name": "arukellt-verified-core-smtlib",
+                  "version": "1",
+                  "executable": "smtlib_v1.py",
               },
               "solver": {
                   "name": "z3",
@@ -80,18 +91,17 @@ jobs:
           )
           PY
 
-      - name: Prove identity contract with Z3
+      - name: Prove generated contracts with Z3
         run: |
-          mkdir -p .build/z3-proof
           python3 scripts/run/run-proof-solver.py \
             --subject tests/proof/verified-core.json \
-            --solver-input tests/proof/z3-identity-vc.smt2 \
+            --solver-input .build/z3-proof/verified-core-vcs.smt2 \
             --toolchain .build/z3-toolchain/toolchain.json \
             --solver-output .build/z3-proof/solver-output.txt \
             --trust-manifest-output .build/z3-proof/trust-manifest.json \
             --proof-receipt-output .build/z3-proof/proof-receipt.json
 
-      - name: Verify real solver identity and bindings
+      - name: Verify translator, solver identity, and bindings
         run: |
           python3 - <<'PY'
           import hashlib
@@ -111,10 +121,14 @@ jobs:
           manifest = json.loads(manifest_path.read_text())
           receipt = json.loads(receipt_path.read_text())
           z3_path = Path(".build/z3-toolchain/z3")
+          translator_path = Path(".build/z3-toolchain/smtlib_v1.py")
           z3_hash = hashlib.sha256(z3_path.read_bytes()).hexdigest()
+          translator_hash = hashlib.sha256(translator_path.read_bytes()).hexdigest()
           assert manifest["solver"]["name"] == "z3", manifest["solver"]
           assert manifest["solver"]["executable_sha256"] == z3_hash
           assert manifest["solver"]["version"].startswith("Z3 version")
+          assert manifest["translator"]["name"] == "arukellt-verified-core-smtlib"
+          assert manifest["translator"]["executable_sha256"] == translator_hash
           assert output.read_text().strip() == "unsat"
           assert receipt["status"] == "proved", receipt
           assert receipt["obligations"] == {
@@ -124,13 +138,13 @@ jobs:
               "unknown": 0,
               "errors": 0,
           }
-          print("z3-proof-run: PASS")
+          print("verified-core-z3-proof-run: PASS")
           PY
 
-      - name: Upload real Z3 proof artifacts
+      - name: Upload generated proof artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: z3-proof-run
+          name: verified-core-z3-proof-run
           path: |
             .build/z3-toolchain/toolchain.json
             .build/z3-proof

--- a/scripts/gen/write-smt-vcs.py
+++ b/scripts/gen/write-smt-vcs.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Generate fail-closed SMT-LIB verification conditions from VerifiedCore v1."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.smtlib_v1 import UnsupportedVerifiedCore, generate_smtlib_file  # noqa: E402
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--subject", type=Path, required=True)
+    result.add_argument("--output", type=Path, required=True)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        count = generate_smtlib_file(args.subject.resolve(), args.output.resolve())
+    except (OSError, ValueError, KeyError, TypeError, UnsupportedVerifiedCore) as exc:
+        print(f"write-smt-vcs: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(f"write-smt-vcs: PASS: obligations={count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/proof/smtlib_v1.py
+++ b/scripts/proof/smtlib_v1.py
@@ -1,0 +1,254 @@
+"""Fail-closed VerifiedCore v1 to SMT-LIB verification-condition adapter."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from proof.common import load_json
+from proof.verified_core import validate_document as validate_verified_core
+
+
+class UnsupportedVerifiedCore(ValueError):
+    """Raised when VerifiedCore is valid but outside the proved SMT subset."""
+
+
+_SYMBOL_RE = re.compile(r"[^A-Za-z0-9_.$!?~-]")
+
+
+def _symbol(raw: str) -> str:
+    value = _SYMBOL_RE.sub("_", raw)
+    if not value:
+        value = "value"
+    if value[0].isdigit():
+        value = "v_" + value
+    return value
+
+
+def _sort(type_entry: dict[str, Any], path: str) -> str:
+    kind = type_entry["kind"]
+    if kind == "integer":
+        return "Int"
+    if kind == "bool":
+        return "Bool"
+    raise UnsupportedVerifiedCore(f"{path}: unsupported SMT type kind: {kind}")
+
+
+def _constant(value: Any, sort: str, path: str) -> str:
+    if sort == "Bool":
+        if value is True:
+            return "true"
+        if value is False:
+            return "false"
+        raise UnsupportedVerifiedCore(f"{path}: expected boolean constant")
+    if sort == "Int":
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise UnsupportedVerifiedCore(f"{path}: expected integer constant")
+        if value < 0:
+            return f"(- {abs(value)})"
+        return str(value)
+    raise UnsupportedVerifiedCore(f"{path}: unsupported constant sort: {sort}")
+
+
+def _typed_value(
+    value: dict[str, Any],
+    local_symbols: dict[int, str],
+    type_sorts: dict[int, str],
+    path: str,
+) -> str:
+    kind = value["kind"]
+    type_id = value["type_id"]
+    sort = type_sorts[type_id]
+    if kind == "local":
+        local_id = value["local_id"]
+        try:
+            return local_symbols[local_id]
+        except KeyError as exc:
+            raise UnsupportedVerifiedCore(f"{path}.local_id: unknown local {local_id}") from exc
+    if kind == "constant":
+        return _constant(value["value"], sort, f"{path}.value")
+    raise UnsupportedVerifiedCore(f"{path}.kind: unsupported return value kind: {kind}")
+
+
+def _expression(
+    expr: dict[str, Any],
+    local_symbols: dict[int, str],
+    type_sorts: dict[int, str],
+    result_symbol: str,
+    path: str,
+) -> str:
+    kind = expr["kind"]
+    type_id = expr["type_id"]
+    sort = type_sorts[type_id]
+    operands = expr.get("operands", [])
+
+    if kind == "local":
+        local_id = expr.get("local_id")
+        if local_id not in local_symbols:
+            raise UnsupportedVerifiedCore(f"{path}.local_id: unknown local {local_id}")
+        return local_symbols[local_id]
+    if kind == "result":
+        return result_symbol
+    if kind == "constant":
+        return _constant(expr.get("value"), sort, f"{path}.value")
+
+    unary = {"not": "not", "neg": "-"}
+    if kind in unary:
+        if len(operands) != 1:
+            raise UnsupportedVerifiedCore(f"{path}.operands: {kind} requires one operand")
+        rendered = _expression(
+            operands[0], local_symbols, type_sorts, result_symbol, f"{path}.operands[0]"
+        )
+        return f"({unary[kind]} {rendered})"
+
+    binary = {
+        "add": "+",
+        "sub": "-",
+        "mul": "*",
+        "div": "div",
+        "mod": "mod",
+        "eq": "=",
+        "ne": "distinct",
+        "lt": "<",
+        "le": "<=",
+        "gt": ">",
+        "ge": ">=",
+        "and": "and",
+        "or": "or",
+        "implies": "=>",
+    }
+    if kind in binary:
+        if len(operands) != 2:
+            raise UnsupportedVerifiedCore(f"{path}.operands: {kind} requires two operands")
+        left = _expression(
+            operands[0], local_symbols, type_sorts, result_symbol, f"{path}.operands[0]"
+        )
+        right = _expression(
+            operands[1], local_symbols, type_sorts, result_symbol, f"{path}.operands[1]"
+        )
+        return f"({binary[kind]} {left} {right})"
+
+    raise UnsupportedVerifiedCore(f"{path}.kind: unsupported proof expression: {kind}")
+
+
+def _single_return(
+    function: dict[str, Any],
+    local_symbols: dict[int, str],
+    type_sorts: dict[int, str],
+    path: str,
+) -> str:
+    body = function["body"]
+    blocks = body["blocks"]
+    if len(blocks) != 1:
+        raise UnsupportedVerifiedCore(f"{path}.body.blocks: only one-block bodies are supported")
+    block = blocks[0]
+    if block["id"] != body["entry_block"]:
+        raise UnsupportedVerifiedCore(f"{path}.body.entry_block: entry block must be the only block")
+    if block["parameters"]:
+        raise UnsupportedVerifiedCore(f"{path}.body.blocks[0].parameters: block parameters unsupported")
+    if block["instructions"]:
+        raise UnsupportedVerifiedCore(f"{path}.body.blocks[0].instructions: instructions unsupported")
+    terminator = block["terminator"]
+    if terminator["kind"] != "return" or "value" not in terminator:
+        raise UnsupportedVerifiedCore(f"{path}.body.blocks[0].terminator: value return required")
+    return _typed_value(
+        terminator["value"],
+        local_symbols,
+        type_sorts,
+        f"{path}.body.blocks[0].terminator.value",
+    )
+
+
+def _function_vcs(
+    function: dict[str, Any],
+    type_sorts: dict[int, str],
+    function_index: int,
+) -> list[str]:
+    path = f"$.functions[{function_index}]"
+    prefix = _symbol(f"f{function['id']}_{function['name']}")
+    local_symbols: dict[int, str] = {}
+    declarations: list[str] = []
+    for local in function["locals"]:
+        local_id = local["id"]
+        symbol = _symbol(f"{prefix}_local_{local_id}_{local['name']}")
+        local_symbols[local_id] = symbol
+        declarations.append(f"(declare-const {symbol} {type_sorts[local['type_id']]})")
+
+    return_type_id = function["signature"]["return_type_id"]
+    result_symbol = _symbol(f"{prefix}_result")
+    declarations.append(f"(declare-const {result_symbol} {type_sorts[return_type_id]})")
+    returned = _single_return(function, local_symbols, type_sorts, path)
+
+    requires: list[str] = []
+    ensures: list[tuple[int, str]] = []
+    for contract_index, contract in enumerate(function["contracts"]):
+        contract_path = f"{path}.contracts[{contract_index}]"
+        rendered = _expression(
+            contract["expression"],
+            local_symbols,
+            type_sorts,
+            result_symbol,
+            f"{contract_path}.expression",
+        )
+        if contract["kind"] == "requires":
+            requires.append(rendered)
+        elif contract["kind"] == "ensures":
+            ensures.append((contract_index, rendered))
+        else:
+            raise UnsupportedVerifiedCore(
+                f"{contract_path}.kind: only requires/ensures are supported"
+            )
+    if not ensures:
+        raise UnsupportedVerifiedCore(f"{path}.contracts: at least one ensures contract is required")
+
+    output: list[str] = declarations
+    for contract_index, ensured in ensures:
+        output.append(f"; obligation {prefix}.ensures[{contract_index}]")
+        output.append("(push 1)")
+        output.append(f"(assert (= {result_symbol} {returned}))")
+        for required in requires:
+            output.append(f"(assert {required})")
+        output.append(f"(assert (not {ensured}))")
+        output.append("(check-sat)")
+        output.append("(pop 1)")
+    return output
+
+
+def generate_smtlib(value: Any) -> str:
+    document = validate_verified_core(value)
+    profile = document["target_profile"]
+    if profile["integer_model"] != "mathematical":
+        raise UnsupportedVerifiedCore("$.target_profile.integer_model: only mathematical is supported")
+    if profile["overflow"] != "checked":
+        raise UnsupportedVerifiedCore("$.target_profile.overflow: only checked is supported")
+    if profile["floating_point"] != "unsupported":
+        raise UnsupportedVerifiedCore("$.target_profile.floating_point: floats must be unsupported")
+
+    type_entries = {entry["id"]: entry for entry in document["types"]}
+    type_sorts = {
+        type_id: _sort(entry, f"$.types[{type_id}]")
+        for type_id, entry in type_entries.items()
+        if entry["kind"] != "unit"
+    }
+
+    lines = ["(set-logic QF_LIA)", "; generated from arukellt-verified-core v1"]
+    obligations = 0
+    for function_index, function in enumerate(document["functions"]):
+        function_lines = _function_vcs(function, type_sorts, function_index)
+        obligations += sum(1 for line in function_lines if line == "(check-sat)")
+        lines.extend(function_lines)
+    if obligations == 0:
+        raise UnsupportedVerifiedCore("$.functions: no proof obligations generated")
+    lines.append("(exit)")
+    return "\n".join(lines) + "\n"
+
+
+def generate_smtlib_file(subject_path: Path, output_path: Path) -> int:
+    rendered = generate_smtlib(load_json(subject_path))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered, encoding="utf-8")
+    return rendered.count("(check-sat)")
+
+
+__all__ = ["UnsupportedVerifiedCore", "generate_smtlib", "generate_smtlib_file"]

--- a/scripts/tests/test_smtlib_v1.py
+++ b/scripts/tests/test_smtlib_v1.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.smtlib_v1 import UnsupportedVerifiedCore, generate_smtlib  # noqa: E402
+
+
+class SmtlibV1Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.subject = json.loads((ROOT / "tests" / "proof" / "verified-core.json").read_text())
+
+    def test_identity_contract_generates_unsat_obligation(self) -> None:
+        output = generate_smtlib(copy.deepcopy(self.subject))
+        self.assertIn("(set-logic QF_LIA)", output)
+        self.assertIn("(assert (= f0_identity_result f0_identity_local_0_x))", output)
+        self.assertIn("(assert (not (>= f0_identity_result f0_identity_local_0_x)))", output)
+        self.assertEqual(output.count("(check-sat)"), 1)
+
+    def test_requires_is_assumed_before_negated_ensures(self) -> None:
+        document = copy.deepcopy(self.subject)
+        function = document["functions"][0]
+        function["contracts"].insert(
+            0,
+            {
+                "kind": "requires",
+                "expression": {
+                    "id": 10,
+                    "kind": "ge",
+                    "type_id": 2,
+                    "operands": [
+                        {"id": 11, "kind": "local", "type_id": 1, "local_id": 0},
+                        {"id": 12, "kind": "constant", "type_id": 1, "value": 0},
+                    ],
+                },
+            },
+        )
+        output = generate_smtlib(document)
+        requirement = "(assert (>= f0_identity_local_0_x 0))"
+        negated_ensure = "(assert (not (>= f0_identity_result f0_identity_local_0_x)))"
+        self.assertLess(output.index(requirement), output.index(negated_ensure))
+
+    def test_body_instructions_fail_closed(self) -> None:
+        document = copy.deepcopy(self.subject)
+        document["functions"][0]["body"]["blocks"][0]["instructions"] = [
+            {"kind": "opaque"}
+        ]
+        with self.assertRaisesRegex(UnsupportedVerifiedCore, "instructions unsupported"):
+            generate_smtlib(document)
+
+    def test_unknown_contract_operator_fails_closed(self) -> None:
+        document = copy.deepcopy(self.subject)
+        document["functions"][0]["contracts"][0]["expression"]["kind"] = "magic"
+        with self.assertRaisesRegex(UnsupportedVerifiedCore, "unsupported proof expression"):
+            generate_smtlib(document)
+
+    def test_machine_integer_profile_fails_closed(self) -> None:
+        document = copy.deepcopy(self.subject)
+        document["target_profile"]["integer_model"] = "machine"
+        with self.assertRaisesRegex(UnsupportedVerifiedCore, "only mathematical"):
+            generate_smtlib(document)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Generate verification conditions directly from validated `arukellt-verified-core` v1 and prove them with the real Z3 driver.

## Supported proof subset

- mathematical integers and booleans
- checked-overflow semantic profile with floats unsupported
- one-block, instruction-free function bodies returning a local or constant
- `requires` and `ensures`
- local/result/constants, arithmetic, comparisons, boolean operators, and implication

Everything outside this subset fails closed.

## Implementation

- adds an independent VerifiedCore v1 → SMT-LIB QF_LIA adapter
- validates VerifiedCore before translation
- asserts the body return relation and all preconditions
- negates each postcondition into a separate solver obligation
- rejects unsupported types, profiles, CFGs, instructions, terminators, contracts, and expression operators
- hashes the exact translator source in TrustManifest
- runs generated VCs through the real Z3 solver driver
- emits and uploads solver output, TrustManifest, ProofReceipt, and generated SMT-LIB

## Validation

- adapter unit tests including unsupported-body/operator/profile failures
- generated identity VC contains one `check-sat`
- real Z3 result is `unsat`
- receipt is `status=proved` with one proved obligation
- translator and solver hashes match the exact executed toolchain bundle
