### PR TITLE
refactor(proof): stop CoreHIR body storage escaping

### DIFF
--- a/.github/workflows/corehir-body-readonly-view.yml
+++ b/.github/workflows/corehir-body-readonly-view.yml
@@ -1,0 +1,57 @@
+name: CoreHIR body readonly view
+
+on:
+  pull_request:
+    branches: [agent/corehir-body-table-seal, agent/formal-verification-hard-gates, master]
+  workflow_dispatch:
+
+concurrency:
+  group: corehir-body-readonly-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  corehir-body-readonly-view:
+    name: "CoreHIR body readonly view"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check storage boundary
+        run: |
+          python3 scripts/check/check-corehir-body-table-seal.py
+          python3 scripts/check/check-corehir-body-readonly-view.py
+
+      - name: Install wasmtime
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.1
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+
+      - name: Build wasm-heap-grow-patcher
+        run: cargo build --release --quiet
+        working-directory: scripts/bootstrap/wasm-heap-grow-patcher
+
+      - name: Build host-linker
+        run: |
+          cargo build --release --quiet
+          cargo test --lib --no-run --quiet
+        working-directory: tools/host-linker
+
+      - name: Build and validate selfhost stages
+        run: |
+          set +e
+          python3 scripts/manager.py selfhost fixpoint --build
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            echo 'selfhost stage build or validation failed'
+            exit 1
+          fi
+          test -s .build/selfhost/arukellt-s2-runtime.wasm
+
+      - name: Compile through detached MIR body snapshot
+        env:
+          ARUKELLT_SELFHOST_WASM: .build/selfhost/arukellt-s2-runtime.wasm
+        run: |
+          mkdir -p .build/proof
+          scripts/run/arukellt-selfhost.sh compile docs/examples/hello.ark -o .build/proof/corehir-readonly-hello.wasm
+          test -s .build/proof/corehir-readonly-hello.wasm

--- a/scripts/check/check-corehir-body-readonly-view.py
+++ b/scripts/check/check-corehir-body-readonly-view.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Check that sealed CoreHIR body-table vectors do not escape their module."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COREHIR = ROOT / "src" / "compiler" / "corehir"
+TABLE = COREHIR / "body_table.ark"
+BODY = COREHIR / "body.ark"
+SOURCE = COREHIR / "mir_body_source.ark"
+
+
+def require(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise ValueError(f"missing {label}: {needle}")
+
+
+def reject(text: str, needle: str, label: str) -> None:
+    if needle in text:
+        raise ValueError(f"forbidden {label}: {needle}")
+
+
+def main() -> int:
+    table = TABLE.read_text(encoding="utf-8")
+    body = BODY.read_text(encoding="utf-8")
+    source = SOURCE.read_text(encoding="utf-8")
+
+    for forbidden in (
+        "fn corehir_body_table_exprs(",
+        "fn corehir_body_table_fn_body_roots(",
+        "fn corehir_body_table_method_body_roots(",
+    ):
+        reject(table, forbidden, "raw table-vector export")
+
+    for forbidden in (
+        "fn body_exprs(",
+        "fn body_fn_roots(",
+        "fn body_method_roots(",
+    ):
+        reject(body, forbidden, "raw body-vector wrapper")
+
+    require(table, "fn corehir_body_table_expr_count", "expression count accessor")
+    require(table, "fn corehir_body_table_expr_at", "expression element accessor")
+    require(body, "fn corehir_body_expr_count", "body expression count wrapper")
+    require(body, "fn corehir_body_expr_at", "body expression element wrapper")
+
+    require(source, "let exprs = Vec::new<CoreHirExpr>()", "detached expression snapshot")
+    require(source, "body::corehir_body_expr_count(table)", "expression count snapshot loop")
+    require(source, "body::corehir_body_expr_at(table, expr_index)", "expression element snapshot")
+    require(source, "let fn_body_roots = Vec::new<i32>()", "detached function-root snapshot")
+    require(source, "let method_body_roots = Vec::new<i32>()", "detached method-root snapshot")
+
+    raw_export_names = (
+        "corehir_body_table_exprs(",
+        "corehir_body_table_fn_body_roots(",
+        "corehir_body_table_method_body_roots(",
+    )
+    violations: list[str] = []
+    for path in ROOT.joinpath("src", "compiler").rglob("*.ark"):
+        text = path.read_text(encoding="utf-8")
+        for name in raw_export_names:
+            if name in text:
+                violations.append(f"{path.relative_to(ROOT)}: {name}")
+    if violations:
+        raise ValueError("raw table storage escape remains: " + "; ".join(violations))
+
+    print("corehir-body-readonly-view: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"corehir-body-readonly-view: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/src/compiler/corehir/body.ark
+++ b/src/compiler/corehir/body.ark
@@ -13,6 +13,10 @@ fn corehir_push_expr(table: CoreHirBodyTable, expr: CoreHirExpr) -> i32 {
     body_table::corehir_body_table_push_expr(table, expr)
 }
 
+fn corehir_body_expr_count(table: CoreHirBodyTable) -> i32 {
+    body_table::corehir_body_table_expr_count(table)
+}
+
 fn corehir_body_expr_at(table: CoreHirBodyTable, index: i32) -> CoreHirExpr {
     body_table::corehir_body_table_expr_at(table, index)
 }
@@ -63,18 +67,6 @@ fn corehir_build_expr(table: CoreHirBodyTable, node: AstNode) -> i32 {
         return stmt_result
     }
     corehir_push_expr(table, expr_factory::CoreHirExpr_unsupported(expr_node_access::expr_span_start(node)))
-}
-
-fn body_exprs(table: CoreHirBodyTable) -> Vec<CoreHirExpr> {
-    body_table::corehir_body_table_exprs(table)
-}
-
-fn body_fn_roots(table: CoreHirBodyTable) -> Vec<i32> {
-    body_table::corehir_body_table_fn_body_roots(table)
-}
-
-fn body_method_roots(table: CoreHirBodyTable) -> Vec<i32> {
-    body_table::corehir_body_table_method_body_roots(table)
 }
 
 fn expr_tree_is_supported(exprs: Vec<CoreHirExpr>, root: i32) -> bool {

--- a/src/compiler/corehir/body_table.ark
+++ b/src/compiler/corehir/body_table.ark
@@ -33,6 +33,10 @@ fn corehir_body_table_push_expr(table: CoreHirBodyTable, expr: CoreHirExpr) -> i
     idx
 }
 
+fn corehir_body_table_expr_count(table: CoreHirBodyTable) -> i32 {
+    len(table.exprs)
+}
+
 fn corehir_body_table_expr_at(table: CoreHirBodyTable, index: i32) -> CoreHirExpr {
     get_unchecked(table.exprs, index)
 }
@@ -77,16 +81,4 @@ fn corehir_body_table_method_body_root_count(table: CoreHirBodyTable) -> i32 {
 
 fn corehir_body_table_method_body_root_at(table: CoreHirBodyTable, index: i32) -> i32 {
     get_unchecked(table.method_body_roots, index)
-}
-
-fn corehir_body_table_exprs(table: CoreHirBodyTable) -> Vec<CoreHirExpr> {
-    table.exprs
-}
-
-fn corehir_body_table_fn_body_roots(table: CoreHirBodyTable) -> Vec<i32> {
-    table.fn_body_roots
-}
-
-fn corehir_body_table_method_body_roots(table: CoreHirBodyTable) -> Vec<i32> {
-    table.method_body_roots
 }

--- a/src/compiler/corehir/mir_body_source.ark
+++ b/src/compiler/corehir/mir_body_source.ark
@@ -7,10 +7,31 @@ struct CoreHirMirBodySource {
 }
 
 fn mir_body_source_from_table(table: CoreHirBodyTable) -> CoreHirMirBodySource {
+    let exprs = Vec::new<CoreHirExpr>()
+    let mut expr_index = 0
+    while expr_index < body::corehir_body_expr_count(table) {
+        push(exprs, body::corehir_body_expr_at(table, expr_index))
+        expr_index = expr_index + 1
+    }
+
+    let fn_body_roots = Vec::new<i32>()
+    let mut fn_index = 0
+    while fn_index < body::corehir_fn_body_root_count(table) {
+        push(fn_body_roots, body::corehir_fn_body_root_at(table, fn_index))
+        fn_index = fn_index + 1
+    }
+
+    let method_body_roots = Vec::new<i32>()
+    let mut method_index = 0
+    while method_index < body::corehir_method_body_root_count(table) {
+        push(method_body_roots, body::corehir_method_body_root_at(table, method_index))
+        method_index = method_index + 1
+    }
+
     CoreHirMirBodySource {
-        exprs: body::body_exprs(table),
-        fn_body_roots: body::body_fn_roots(table),
-        method_body_roots: body::body_method_roots(table),
+        exprs: exprs,
+        fn_body_roots: fn_body_roots,
+        method_body_roots: method_body_roots,
     }
 }
 


### PR DESCRIPTION
## Scope

Remove the APIs that return the sealed CoreHIR body's internal mutable vectors.

## Implementation

- deletes raw exports for expression, function-root, and method-root vectors
- adds expression count/element accessors alongside the existing root accessors
- constructs the MIR body source as detached vectors through count/at iteration
- keeps the sealed table storage private to `body_table.ark`
- adds a repository-wide source contract that rejects any remaining raw storage-export API
- preserves the #24 `sealed && !mutation_violation` pipeline admission gate

## Non-claims

- `CoreHirMirBodySource` still uses mutable Vec storage internally after snapshot construction
- this does not yet introduce persistent collections or a nominal immutable arena type
- construction-time mutation inside `CoreHirBodyTable` remains intentional

## Validation

- `python3 scripts/check/check-corehir-body-table-seal.py`
- `python3 scripts/check/check-corehir-body-readonly-view.py`
- selfhost s2/s3 build and validation
- compile a fixture through the detached MIR body snapshot
