### PR TITLE
feat(proof): integrate semantically typed VerifiedCore boundary

### DIFF
--- a/.github/workflows/typed-corehir-proof-pipeline.yml
+++ b/.github/workflows/typed-corehir-proof-pipeline.yml
@@ -34,6 +34,7 @@ jobs:
             scripts.tests.test_typed_verified_core_receipt \
             scripts.tests.test_smtlib_v1 \
             scripts.tests.test_solver_receipts \
+            scripts.tests.test_solver_result \
             scripts.tests.test_solver_driver
 
       - name: Convert TypedCoreHIR into semantically typed VerifiedCore
@@ -103,77 +104,19 @@ jobs:
               },
               "assumptions": [],
               "trusted_components": [
-                  {
-                      "name": "arukellt-typed-corehir-to-verified-core-v2",
-                      "role": "typed-proof-boundary",
-                      "version": "2",
-                      "artifact": "typed_corehir_typed_convert.py",
-                  },
-                  {
-                      "name": "arukellt-typed-corehir-converter-implementation-v1",
-                      "role": "typed-proof-boundary-implementation",
-                      "version": "1",
-                      "artifact": "typed_corehir_convert.py",
-                  },
-                  {
-                      "name": "arukellt-verified-core-structural-validator-v1",
-                      "role": "artifact-validator",
-                      "version": "1",
-                      "artifact": "verified_core.py",
-                  },
-                  {
-                      "name": "arukellt-verified-core-semantic-validator-v1",
-                      "role": "typed-artifact-validator",
-                      "version": "1",
-                      "artifact": "verified_core_typed.py",
-                  },
-                  {
-                      "name": "arukellt-typed-verified-core-admission-cli-v1",
-                      "role": "typed-artifact-admission",
-                      "version": "1",
-                      "artifact": "check-typed-verified-core.py",
-                  },
-                  {
-                      "name": "arukellt-typed-verified-core-smt-adapter-v1",
-                      "role": "typed-smt-adapter",
-                      "version": "1",
-                      "artifact": "smtlib_typed_v1.py",
-                  },
-                  {
-                      "name": "arukellt-smt-renderer-v1",
-                      "role": "smt-renderer-implementation",
-                      "version": "1",
-                      "artifact": "smtlib_v1.py",
-                  },
-                  {
-                      "name": "arukellt-typed-verified-core-boundary-policy-v1",
-                      "role": "typed-boundary-policy",
-                      "version": "1",
-                      "artifact": "check-typed-verified-core-boundary.py",
-                  },
-                  {
-                      "name": "arukellt-typed-verified-core-receipt-validator-v1",
-                      "role": "typed-boundary-receipt-validator",
-                      "version": "1",
-                      "artifact": "typed_verified_core_receipt.py",
-                  },
-                  {
-                      "name": "arukellt-typed-verified-core-receipt-checker-v1",
-                      "role": "typed-boundary-receipt-checker",
-                      "version": "1",
-                      "artifact": "check-typed-verified-core-boundary-receipt.py",
-                  },
-                  {
-                      "name": "arukellt-typed-verified-core-boundary-receipt-v1",
-                      "role": "typed-boundary-receipt",
-                      "version": "1",
-                      "artifact": "typed-verified-core-boundary.json",
-                  },
+                  {"name": "arukellt-typed-corehir-to-verified-core-v2", "role": "typed-proof-boundary", "version": "2", "artifact": "typed_corehir_typed_convert.py"},
+                  {"name": "arukellt-typed-corehir-converter-implementation-v1", "role": "typed-proof-boundary-implementation", "version": "1", "artifact": "typed_corehir_convert.py"},
+                  {"name": "arukellt-verified-core-structural-validator-v1", "role": "artifact-validator", "version": "1", "artifact": "verified_core.py"},
+                  {"name": "arukellt-verified-core-semantic-validator-v1", "role": "typed-artifact-validator", "version": "1", "artifact": "verified_core_typed.py"},
+                  {"name": "arukellt-typed-verified-core-admission-cli-v1", "role": "typed-artifact-admission", "version": "1", "artifact": "check-typed-verified-core.py"},
+                  {"name": "arukellt-typed-verified-core-smt-adapter-v1", "role": "typed-smt-adapter", "version": "1", "artifact": "smtlib_typed_v1.py"},
+                  {"name": "arukellt-smt-renderer-v1", "role": "smt-renderer-implementation", "version": "1", "artifact": "smtlib_v1.py"},
+                  {"name": "arukellt-typed-verified-core-boundary-policy-v1", "role": "typed-boundary-policy", "version": "1", "artifact": "check-typed-verified-core-boundary.py"},
+                  {"name": "arukellt-typed-verified-core-receipt-validator-v1", "role": "typed-boundary-receipt-validator", "version": "1", "artifact": "typed_verified_core_receipt.py"},
+                  {"name": "arukellt-typed-verified-core-receipt-checker-v1", "role": "typed-boundary-receipt-checker", "version": "1", "artifact": "check-typed-verified-core-boundary-receipt.py"},
+                  {"name": "arukellt-typed-verified-core-boundary-receipt-v1", "role": "typed-boundary-receipt", "version": "1", "artifact": "typed-verified-core-boundary.json"},
               ],
-              "limits": {
-                  "timeout_ms": 10000,
-                  "memory_bytes": 1073741824,
-              },
+              "limits": {"timeout_ms": 10000, "memory_bytes": 1073741824},
           }
           Path(".build/typed-corehir-toolchain/toolchain.json").write_text(
               json.dumps(document, indent=2) + "\n",
@@ -189,7 +132,16 @@ jobs:
             --toolchain .build/typed-corehir-toolchain/toolchain.json \
             --solver-output .build/typed-corehir-proof/solver-output.txt \
             --trust-manifest-output .build/typed-corehir-proof/trust-manifest.json \
-            --proof-receipt-output .build/typed-corehir-proof/proof-receipt.json
+            --proof-receipt-output .build/typed-corehir-proof/proof-receipt.json \
+            --solver-result-output .build/typed-corehir-proof/solver-result.json
+          python3 scripts/check/check-solver-result.py \
+            .build/typed-corehir-proof/solver-result.json \
+            --subject .build/typed-corehir-proof/verified-core.json \
+            --solver-input .build/typed-corehir-proof/verified-core-vcs.smt2 \
+            --toolchain .build/typed-corehir-toolchain/toolchain.json \
+            --solver-output .build/typed-corehir-proof/solver-output.txt \
+            --trust-manifest .build/typed-corehir-proof/trust-manifest.json \
+            --proof-receipt .build/typed-corehir-proof/proof-receipt.json
 
       - name: Verify typed end-to-end bindings
         run: |

--- a/.github/workflows/typed-corehir-proof-pipeline.yml
+++ b/.github/workflows/typed-corehir-proof-pipeline.yml
@@ -1,0 +1,253 @@
+name: TypedCoreHIR proof pipeline
+
+on:
+  pull_request:
+    branches: [agent/verified-core-smtlib-vc, agent/z3-proof-run, agent/proof-solver-driver, agent/solver-bound-proof-receipts, agent/formal-verification-hard-gates, master]
+  workflow_dispatch:
+
+concurrency:
+  group: typed-corehir-proof-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typed-corehir-proof-pipeline:
+    name: "TypedCoreHIR proof pipeline"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reject untyped or name-inferred conversion paths
+        run: python3 scripts/check/check-typed-verified-core-boundary.py
+
+      - name: Write and independently validate typed boundary receipt
+        run: |
+          python3 scripts/gen/write-typed-verified-core-boundary-receipt.py
+          python3 scripts/check/check-typed-verified-core-boundary-receipt.py \
+            .build/proof/typed-verified-core-boundary.json
+
+      - name: Test conversion, semantic typing, and VC generation
+        run: |
+          python3 -m unittest \
+            scripts.tests.test_typed_corehir_convert \
+            scripts.tests.test_verified_core_typed \
+            scripts.tests.test_smtlib_typed_v1 \
+            scripts.tests.test_typed_verified_core_receipt \
+            scripts.tests.test_smtlib_v1 \
+            scripts.tests.test_solver_receipts \
+            scripts.tests.test_solver_driver
+
+      - name: Convert TypedCoreHIR into semantically typed VerifiedCore
+        run: |
+          mkdir -p .build/typed-corehir-proof
+          python3 scripts/gen/convert-typed-corehir.py \
+            --input tests/proof/typed-corehir.json \
+            --output .build/typed-corehir-proof/verified-core.json
+          python3 scripts/check/check-typed-verified-core.py \
+            .build/typed-corehir-proof/verified-core.json
+          python3 scripts/gen/write-smt-vcs.py \
+            --subject .build/typed-corehir-proof/verified-core.json \
+            --output .build/typed-corehir-proof/verified-core-vcs.smt2
+
+      - name: Install Z3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y z3
+          z3 --version
+
+      - name: Build hash-bound typed proof toolchain
+        run: |
+          mkdir -p .build/typed-corehir-toolchain
+          cp "$(command -v z3)" .build/typed-corehir-toolchain/z3
+          cp tests/proof/toolchain/producer.bin .build/typed-corehir-toolchain/producer.bin
+          cp scripts/proof/smtlib_typed_v1.py .build/typed-corehir-toolchain/smtlib_typed_v1.py
+          cp scripts/proof/smtlib_v1.py .build/typed-corehir-toolchain/smtlib_v1.py
+          cp scripts/proof/typed_corehir_typed_convert.py .build/typed-corehir-toolchain/typed_corehir_typed_convert.py
+          cp scripts/proof/typed_corehir_convert.py .build/typed-corehir-toolchain/typed_corehir_convert.py
+          cp scripts/proof/verified_core.py .build/typed-corehir-toolchain/verified_core.py
+          cp scripts/proof/verified_core_typed.py .build/typed-corehir-toolchain/verified_core_typed.py
+          cp scripts/proof/typed_verified_core_receipt.py .build/typed-corehir-toolchain/typed_verified_core_receipt.py
+          cp scripts/check/check-typed-verified-core.py .build/typed-corehir-toolchain/check-typed-verified-core.py
+          cp scripts/check/check-typed-verified-core-boundary.py .build/typed-corehir-toolchain/check-typed-verified-core-boundary.py
+          cp scripts/check/check-typed-verified-core-boundary-receipt.py .build/typed-corehir-toolchain/check-typed-verified-core-boundary-receipt.py
+          cp .build/proof/typed-verified-core-boundary.json .build/typed-corehir-toolchain/typed-verified-core-boundary.json
+          python3 - <<'PY'
+          import json
+          import subprocess
+          from pathlib import Path
+
+          version = subprocess.check_output(["z3", "--version"], text=True).strip()
+          document = {
+              "schema": "arukellt-proof-toolchain",
+              "schema_version": 1,
+              "producer": {
+                  "name": "arukellt-typed-corehir-fixture",
+                  "version": "1",
+                  "executable": "producer.bin",
+              },
+              "translator": {
+                  "name": "arukellt-typed-verified-core-smtlib",
+                  "version": "1",
+                  "executable": "smtlib_typed_v1.py",
+              },
+              "solver": {
+                  "name": "z3",
+                  "version": version,
+                  "executable": "z3",
+                  "arguments": ["-in", "-smt2"],
+              },
+              "semantic_profile": {
+                  "integer_model": "mathematical",
+                  "overflow": "checked",
+                  "floating_point": "unsupported",
+                  "memory": "pure-values",
+              },
+              "assumptions": [],
+              "trusted_components": [
+                  {
+                      "name": "arukellt-typed-corehir-to-verified-core-v2",
+                      "role": "typed-proof-boundary",
+                      "version": "2",
+                      "artifact": "typed_corehir_typed_convert.py",
+                  },
+                  {
+                      "name": "arukellt-typed-corehir-converter-implementation-v1",
+                      "role": "typed-proof-boundary-implementation",
+                      "version": "1",
+                      "artifact": "typed_corehir_convert.py",
+                  },
+                  {
+                      "name": "arukellt-verified-core-structural-validator-v1",
+                      "role": "artifact-validator",
+                      "version": "1",
+                      "artifact": "verified_core.py",
+                  },
+                  {
+                      "name": "arukellt-verified-core-semantic-validator-v1",
+                      "role": "typed-artifact-validator",
+                      "version": "1",
+                      "artifact": "verified_core_typed.py",
+                  },
+                  {
+                      "name": "arukellt-typed-verified-core-admission-cli-v1",
+                      "role": "typed-artifact-admission",
+                      "version": "1",
+                      "artifact": "check-typed-verified-core.py",
+                  },
+                  {
+                      "name": "arukellt-typed-verified-core-smt-adapter-v1",
+                      "role": "typed-smt-adapter",
+                      "version": "1",
+                      "artifact": "smtlib_typed_v1.py",
+                  },
+                  {
+                      "name": "arukellt-smt-renderer-v1",
+                      "role": "smt-renderer-implementation",
+                      "version": "1",
+                      "artifact": "smtlib_v1.py",
+                  },
+                  {
+                      "name": "arukellt-typed-verified-core-boundary-policy-v1",
+                      "role": "typed-boundary-policy",
+                      "version": "1",
+                      "artifact": "check-typed-verified-core-boundary.py",
+                  },
+                  {
+                      "name": "arukellt-typed-verified-core-receipt-validator-v1",
+                      "role": "typed-boundary-receipt-validator",
+                      "version": "1",
+                      "artifact": "typed_verified_core_receipt.py",
+                  },
+                  {
+                      "name": "arukellt-typed-verified-core-receipt-checker-v1",
+                      "role": "typed-boundary-receipt-checker",
+                      "version": "1",
+                      "artifact": "check-typed-verified-core-boundary-receipt.py",
+                  },
+                  {
+                      "name": "arukellt-typed-verified-core-boundary-receipt-v1",
+                      "role": "typed-boundary-receipt",
+                      "version": "1",
+                      "artifact": "typed-verified-core-boundary.json",
+                  },
+              ],
+              "limits": {
+                  "timeout_ms": 10000,
+                  "memory_bytes": 1073741824,
+              },
+          }
+          Path(".build/typed-corehir-toolchain/toolchain.json").write_text(
+              json.dumps(document, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Prove converted VerifiedCore with Z3
+        run: |
+          python3 scripts/run/run-proof-solver.py \
+            --subject .build/typed-corehir-proof/verified-core.json \
+            --solver-input .build/typed-corehir-proof/verified-core-vcs.smt2 \
+            --toolchain .build/typed-corehir-toolchain/toolchain.json \
+            --solver-output .build/typed-corehir-proof/solver-output.txt \
+            --trust-manifest-output .build/typed-corehir-proof/trust-manifest.json \
+            --proof-receipt-output .build/typed-corehir-proof/proof-receipt.json
+
+      - name: Verify typed end-to-end bindings
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import sys
+          from pathlib import Path
+
+          sys.path.insert(0, "scripts")
+          from proof.trust import validate_bound_proof
+          from proof.typed_verified_core_receipt import validate_boundary_receipt
+          from proof.verified_core_typed import validate_typed_document
+
+          root = Path(".build/typed-corehir-proof")
+          toolchain = Path(".build/typed-corehir-toolchain")
+          subject = root / "verified-core.json"
+          manifest_path = root / "trust-manifest.json"
+          receipt_path = root / "proof-receipt.json"
+          solver_output = root / "solver-output.txt"
+          boundary_receipt = Path(".build/proof/typed-verified-core-boundary.json")
+          validate_typed_document(json.loads(subject.read_text()))
+          validate_boundary_receipt(json.loads(boundary_receipt.read_text()), root=Path.cwd())
+          validate_bound_proof(subject, manifest_path, receipt_path, solver_output)
+
+          manifest = json.loads(manifest_path.read_text())
+          receipt = json.loads(receipt_path.read_text())
+          expected = {
+              "typed-proof-boundary": "typed_corehir_typed_convert.py",
+              "typed-proof-boundary-implementation": "typed_corehir_convert.py",
+              "artifact-validator": "verified_core.py",
+              "typed-artifact-validator": "verified_core_typed.py",
+              "typed-artifact-admission": "check-typed-verified-core.py",
+              "typed-smt-adapter": "smtlib_typed_v1.py",
+              "smt-renderer-implementation": "smtlib_v1.py",
+              "typed-boundary-policy": "check-typed-verified-core-boundary.py",
+              "typed-boundary-receipt-validator": "typed_verified_core_receipt.py",
+              "typed-boundary-receipt-checker": "check-typed-verified-core-boundary-receipt.py",
+              "typed-boundary-receipt": "typed-verified-core-boundary.json",
+          }
+          by_role = {item["role"]: item for item in manifest["trusted_components"]}
+          for role, filename in expected.items():
+              digest = hashlib.sha256((toolchain / filename).read_bytes()).hexdigest()
+              assert by_role[role]["artifact_sha256"] == digest
+          assert manifest["translator"]["executable_sha256"] == hashlib.sha256(
+              (toolchain / "smtlib_typed_v1.py").read_bytes()
+          ).hexdigest()
+          assert solver_output.read_text().strip() == "unsat"
+          assert receipt["status"] == "proved", receipt
+          print("typed-corehir-proof-pipeline: PASS: typed_semantics=bound-through-solver")
+          PY
+
+      - name: Upload end-to-end proof bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: typed-corehir-proof-pipeline
+          path: |
+            .build/typed-corehir-proof
+            .build/typed-corehir-toolchain/toolchain.json
+            .build/proof/typed-verified-core-boundary.json
+          if-no-files-found: error

--- a/.github/workflows/z3-proof-run.yml
+++ b/.github/workflows/z3-proof-run.yml
@@ -16,8 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Test VerifiedCore SMT adapter
-        run: python3 -m unittest scripts.tests.test_smtlib_v1
+      - name: Test VerifiedCore SMT adapter and SolverResult
+        run: |
+          python3 -m unittest \
+            scripts.tests.test_smtlib_v1 \
+            scripts.tests.test_solver_result
 
       - name: Install Z3
         run: |
@@ -80,10 +83,7 @@ jobs:
                       "artifact": "trusted-component.txt",
                   }
               ],
-              "limits": {
-                  "timeout_ms": 10000,
-                  "memory_bytes": 1073741824,
-              },
+              "limits": {"timeout_ms": 10000, "memory_bytes": 1073741824},
           }
           Path(".build/z3-toolchain/toolchain.json").write_text(
               json.dumps(document, indent=2) + "\n",
@@ -99,7 +99,16 @@ jobs:
             --toolchain .build/z3-toolchain/toolchain.json \
             --solver-output .build/z3-proof/solver-output.txt \
             --trust-manifest-output .build/z3-proof/trust-manifest.json \
-            --proof-receipt-output .build/z3-proof/proof-receipt.json
+            --proof-receipt-output .build/z3-proof/proof-receipt.json \
+            --solver-result-output .build/z3-proof/solver-result.json
+          python3 scripts/check/check-solver-result.py \
+            .build/z3-proof/solver-result.json \
+            --subject tests/proof/verified-core.json \
+            --solver-input .build/z3-proof/verified-core-vcs.smt2 \
+            --toolchain .build/z3-toolchain/toolchain.json \
+            --solver-output .build/z3-proof/solver-output.txt \
+            --trust-manifest .build/z3-proof/trust-manifest.json \
+            --proof-receipt .build/z3-proof/proof-receipt.json
 
       - name: Verify translator, solver identity, and bindings
         run: |
@@ -122,22 +131,11 @@ jobs:
           receipt = json.loads(receipt_path.read_text())
           z3_path = Path(".build/z3-toolchain/z3")
           translator_path = Path(".build/z3-toolchain/smtlib_v1.py")
-          z3_hash = hashlib.sha256(z3_path.read_bytes()).hexdigest()
-          translator_hash = hashlib.sha256(translator_path.read_bytes()).hexdigest()
-          assert manifest["solver"]["name"] == "z3", manifest["solver"]
-          assert manifest["solver"]["executable_sha256"] == z3_hash
-          assert manifest["solver"]["version"].startswith("Z3 version")
-          assert manifest["translator"]["name"] == "arukellt-verified-core-smtlib"
-          assert manifest["translator"]["executable_sha256"] == translator_hash
+          assert manifest["solver"]["name"] == "z3"
+          assert manifest["solver"]["executable_sha256"] == hashlib.sha256(z3_path.read_bytes()).hexdigest()
+          assert manifest["translator"]["executable_sha256"] == hashlib.sha256(translator_path.read_bytes()).hexdigest()
           assert output.read_text().strip() == "unsat"
           assert receipt["status"] == "proved", receipt
-          assert receipt["obligations"] == {
-              "total": 1,
-              "proved": 1,
-              "refuted": 0,
-              "unknown": 0,
-              "errors": 0,
-          }
           print("verified-core-z3-proof-run: PASS")
           PY
 

--- a/release/proof-policy.json
+++ b/release/proof-policy.json
@@ -5,7 +5,7 @@
   "hard_gates": {
     "versioned_boundary_artifacts": false,
     "explicit_backend_type_abi_layout": true,
-    "typed_verified_core_emission": false,
+    "typed_verified_core_emission": true,
     "optimizer_translation_validation": true,
     "solver_trust_manifest": true,
     "legacy_mutable_table_removed": false,

--- a/scripts/check/check-typed-verified-core-boundary-receipt.py
+++ b/scripts/check/check-typed-verified-core-boundary-receipt.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Validate typed VerifiedCore boundary receipt and all bound files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.typed_verified_core_receipt import (  # noqa: E402
+    TypedVerifiedCoreReceiptError,
+    validate_boundary_receipt,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("receipt", type=Path)
+    args = parser.parse_args()
+    try:
+        value = json.loads(args.receipt.read_text(encoding="utf-8"))
+        document = validate_boundary_receipt(value, root=ROOT)
+    except (
+        OSError,
+        json.JSONDecodeError,
+        ValueError,
+        TypeError,
+        TypedVerifiedCoreReceiptError,
+    ) as exc:
+        print(f"typed-verified-core-boundary-receipt: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "typed-verified-core-boundary-receipt: PASS: "
+        f"files={len(document['files'])} semantic_checks={len(document['semantic_checks'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check/check-typed-verified-core-boundary.py
+++ b/scripts/check/check-typed-verified-core-boundary.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Reject untyped or name-inferred TypedCoreHIR to VerifiedCore paths."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CLI = ROOT / "scripts" / "gen" / "convert-typed-corehir.py"
+SMT_CLI = ROOT / "scripts" / "gen" / "write-smt-vcs.py"
+BOUNDARY = ROOT / "scripts" / "proof" / "typed_corehir_typed_convert.py"
+SEMANTICS = ROOT / "scripts" / "proof" / "verified_core_typed.py"
+TYPED_SMT = ROOT / "scripts" / "proof" / "smtlib_typed_v1.py"
+RECEIPT_VALIDATOR = ROOT / "scripts" / "proof" / "typed_verified_core_receipt.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "typed-corehir-proof-pipeline.yml"
+POLICY_SELF = "scripts/check/check-typed-verified-core-boundary.py"
+
+
+def require(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise ValueError(f"missing {label}: {token}")
+
+
+def reject_production_bypasses() -> None:
+    allowed_legacy_converter = {
+        "scripts/proof/typed_corehir_typed_convert.py",
+        POLICY_SELF,
+    }
+    allowed_structural_smt = {
+        "scripts/proof/smtlib_typed_v1.py",
+        POLICY_SELF,
+    }
+    violations: list[str] = []
+    for path in sorted((ROOT / "scripts").rglob("*.py")):
+        relative = path.relative_to(ROOT).as_posix()
+        if relative.startswith("scripts/tests/"):
+            continue
+        text = path.read_text(encoding="utf-8")
+        if (
+            "from proof.typed_corehir_convert import" in text
+            and relative not in allowed_legacy_converter
+        ):
+            violations.append(f"{relative}: direct legacy TypedCoreHIR converter import")
+        if (
+            "from proof.smtlib_v1 import" in text
+            and relative not in allowed_structural_smt
+        ):
+            violations.append(f"{relative}: direct structural-only SMT renderer import")
+    if violations:
+        raise ValueError("\n".join(violations))
+
+
+def main() -> int:
+    cli = CLI.read_text(encoding="utf-8")
+    smt_cli = SMT_CLI.read_text(encoding="utf-8")
+    boundary = BOUNDARY.read_text(encoding="utf-8")
+    semantics = SEMANTICS.read_text(encoding="utf-8")
+    typed_smt = TYPED_SMT.read_text(encoding="utf-8")
+    receipt_validator = RECEIPT_VALIDATOR.read_text(encoding="utf-8")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    require(cli, "from proof.typed_corehir_typed_convert import", "v2 CLI import")
+    require(cli, "convert_typed_document", "v2 CLI call")
+    if "from proof.typed_corehir_convert import" in cli:
+        raise ValueError("public converter CLI bypasses explicit typed v2 boundary")
+
+    for token, label in (
+        ('"bits"', "explicit integer bit width"),
+        ('"signed"', "explicit integer signedness"),
+        ("legacy[\"name\"] = expected", "metadata-derived legacy normalization"),
+        ("rendered[\"name\"] = explicit[\"name\"]", "source identity preservation"),
+        ("return validate_typed_document(converted)", "semantic admission"),
+    ):
+        require(boundary, token, label)
+
+    forbidden_name_inference = (
+        'explicit["name"] == "i32"',
+        'explicit["name"] == "i64"',
+        'raw.get("name") == "i32"',
+        'raw.get("name") == "i64"',
+        'startswith(explicit["name"]',
+    )
+    for token in forbidden_name_inference:
+        if token in boundary:
+            raise ValueError(f"source type-name inference reintroduced: {token}")
+
+    for token, label in (
+        ("contract must have type bool", "contract root typing"),
+        ("result type does not match function return type", "result typing"),
+        ("binary operands must have identical TypeId", "binary TypeId equality"),
+        ("arithmetic must preserve operand TypeId", "arithmetic preservation"),
+        ("signature parameter", "parameter/local correspondence"),
+        ("integer constant requires an integer value", "constant payload typing"),
+    ):
+        require(semantics, token, label)
+
+    require(
+        smt_cli,
+        "from proof.smtlib_typed_v1 import",
+        "typed SMT CLI import",
+    )
+    if "from proof.smtlib_v1 import" in smt_cli:
+        raise ValueError("SMT CLI bypasses typed VerifiedCore admission")
+    for token, label in (
+        ("validate_typed_document(value)", "semantic admission before SMT"),
+        ("return generate_smtlib(document)", "post-admission SMT rendering"),
+    ):
+        require(typed_smt, token, label)
+
+    for token, label in (
+        ("REQUIRED_SEMANTIC_CHECKS", "receipt semantic check registry"),
+        ("sha256_file(path)", "receipt file digest verification"),
+        ("duplicate path", "receipt duplicate path rejection"),
+    ):
+        require(receipt_validator, token, label)
+
+    for token, label in (
+        ("scripts.tests.test_verified_core_typed", "semantic negative tests"),
+        ("scripts.tests.test_smtlib_typed_v1", "typed SMT negative tests"),
+        ("scripts.tests.test_typed_verified_core_receipt", "receipt negative tests"),
+        ("verified_core_typed.py", "semantic validator TrustManifest component"),
+        ("typed_corehir_typed_convert.py", "v2 converter TrustManifest component"),
+        ("smtlib_typed_v1.py", "typed SMT TrustManifest component"),
+        ("typed_verified_core_receipt.py", "receipt validator TrustManifest component"),
+        ("check-typed-verified-core.py", "standalone typed admission"),
+        ("write-typed-verified-core-boundary-receipt.py", "versioned boundary receipt"),
+        ("check-typed-verified-core-boundary-receipt.py", "independent receipt check"),
+        ("check-typed-verified-core-boundary.py", "source gate execution"),
+    ):
+        require(workflow, token, label)
+
+    reject_production_bypasses()
+    print(
+        "typed-verified-core-boundary: PASS: "
+        "explicit logical types and semantic admission enforced through SMT"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"typed-verified-core-boundary: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/check/check-typed-verified-core.py
+++ b/scripts/check/check-typed-verified-core.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Validate structural and semantic typing of a VerifiedCore v1 artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.verified_core_typed import (  # noqa: E402
+    TypedVerifiedCoreError,
+    validate_typed_document,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifact", type=Path)
+    args = parser.parse_args()
+    try:
+        value = json.loads(args.artifact.read_text(encoding="utf-8"))
+        document = validate_typed_document(value)
+    except (OSError, json.JSONDecodeError, ValueError, TypeError, KeyError, TypedVerifiedCoreError) as exc:
+        print(f"typed-verified-core: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "typed-verified-core: PASS: "
+        f"types={len(document['types'])} functions={len(document['functions'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen/convert-typed-corehir.py
+++ b/scripts/gen/convert-typed-corehir.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Convert TypedCoreHIR v1 into semantically typed VerifiedCore v1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.common import load_json  # noqa: E402
+from proof.typed_corehir_typed_convert import (  # noqa: E402
+    ExplicitTypedCoreHirError,
+    convert_typed_document,
+)
+from proof.verified_core_typed import TypedVerifiedCoreError  # noqa: E402
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--input", type=Path, required=True)
+    result.add_argument("--output", type=Path, required=True)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        converted = convert_typed_document(load_json(args.input.resolve()))
+        output = args.output.resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(converted, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except (
+        OSError,
+        ValueError,
+        TypeError,
+        KeyError,
+        ExplicitTypedCoreHirError,
+        TypedVerifiedCoreError,
+    ) as exc:
+        print(f"convert-typed-corehir: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "convert-typed-corehir: PASS: "
+        f"types={len(converted['types'])} functions={len(converted['functions'])} "
+        "explicit_types=validated typed_semantics=validated"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen/write-smt-vcs.py
+++ b/scripts/gen/write-smt-vcs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate fail-closed SMT-LIB verification conditions from VerifiedCore v1."""
+"""Generate fail-closed SMT-LIB VCs from semantically typed VerifiedCore v1."""
 
 from __future__ import annotations
 
@@ -12,7 +12,10 @@ SCRIPTS = ROOT / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
-from proof.smtlib_v1 import UnsupportedVerifiedCore, generate_smtlib_file  # noqa: E402
+from proof.smtlib_typed_v1 import (  # noqa: E402
+    UnsupportedTypedVerifiedCore,
+    generate_typed_smtlib_file,
+)
 
 
 def parser() -> argparse.ArgumentParser:
@@ -25,11 +28,20 @@ def parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = parser().parse_args()
     try:
-        count = generate_smtlib_file(args.subject.resolve(), args.output.resolve())
-    except (OSError, ValueError, KeyError, TypeError, UnsupportedVerifiedCore) as exc:
+        count = generate_typed_smtlib_file(
+            args.subject.resolve(),
+            args.output.resolve(),
+        )
+    except (
+        OSError,
+        ValueError,
+        KeyError,
+        TypeError,
+        UnsupportedTypedVerifiedCore,
+    ) as exc:
         print(f"write-smt-vcs: FAIL: {exc}", file=sys.stderr)
         return 1
-    print(f"write-smt-vcs: PASS: obligations={count}")
+    print(f"write-smt-vcs: PASS: obligations={count} typed_semantics=validated")
     return 0
 
 

--- a/scripts/gen/write-typed-verified-core-boundary-receipt.py
+++ b/scripts/gen/write-typed-verified-core-boundary-receipt.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Write hash-bound evidence for the typed VerifiedCore admission boundary."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BOUNDARY_FILES = (
+    "scripts/gen/convert-typed-corehir.py",
+    "scripts/gen/write-smt-vcs.py",
+    "scripts/gen/write-typed-verified-core-boundary-receipt.py",
+    "scripts/proof/typed_corehir_typed_convert.py",
+    "scripts/proof/typed_corehir_convert.py",
+    "scripts/proof/verified_core.py",
+    "scripts/proof/verified_core_typed.py",
+    "scripts/proof/typed_verified_core_receipt.py",
+    "scripts/proof/smtlib_typed_v1.py",
+    "scripts/proof/smtlib_v1.py",
+    "scripts/check/check-typed-verified-core.py",
+    "scripts/check/check-typed-verified-core-boundary.py",
+    "scripts/check/check-typed-verified-core-boundary-receipt.py",
+    "scripts/tests/test_typed_corehir_convert.py",
+    "scripts/tests/test_verified_core_typed.py",
+    "scripts/tests/test_smtlib_typed_v1.py",
+    "scripts/tests/test_typed_verified_core_receipt.py",
+    "tests/proof/typed-corehir.json",
+    ".github/workflows/typed-corehir-proof-pipeline.yml",
+    "release/proof-policy.json",
+)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "typed-verified-core-boundary.json",
+    )
+    args = parser.parse_args()
+
+    files: list[dict[str, str]] = []
+    for relative in BOUNDARY_FILES:
+        path = ROOT / relative
+        if not path.is_file():
+            raise ValueError(f"typed VerifiedCore boundary file missing: {relative}")
+        files.append({"path": relative, "sha256": sha256(path)})
+
+    document = {
+        "schema": "arukellt-typed-verified-core-boundary",
+        "schema_version": 1,
+        "status": "enforced",
+        "source_schema": "arukellt-typed-corehir@1",
+        "target_schema": "arukellt-verified-core@1",
+        "converter": "arukellt-typed-corehir-converter-v2",
+        "logical_integer_metadata": "explicit-bits-and-signedness",
+        "type_name_semantics": "identity-only",
+        "structural_validator": "verified_core.py@1",
+        "semantic_validator": "verified_core_typed.py@1",
+        "solver_adapter": "smtlib_typed_v1.py@1",
+        "semantic_checks": [
+            "operator-arity-and-TypeId-preservation",
+            "contract-root-typing",
+            "result-return-TypeId-equality",
+            "parameter-signature-local-bijection",
+            "constant-payload-typing",
+            "global-contract-expression-id-uniqueness",
+            "semantic-admission-before-SMT",
+        ],
+        "failure_action": "reject-before-SMT-generation",
+        "files": files,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        "typed-verified-core-boundary-receipt: PASS: "
+        f"files={len(files)} output={args.output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"typed-verified-core-boundary-receipt: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/proof/smtlib_typed_v1.py
+++ b/scripts/proof/smtlib_typed_v1.py
@@ -1,0 +1,41 @@
+"""Typed VerifiedCore v1 to SMT-LIB adapter.
+
+This is the public proof adapter. It performs semantic typed admission before
+calling the syntax-oriented SMT renderer, so malformed TypeIds or operators
+cannot reach the solver through another caller.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from proof.common import load_json
+from proof.smtlib_v1 import UnsupportedVerifiedCore, generate_smtlib
+from proof.verified_core_typed import validate_typed_document
+
+
+class UnsupportedTypedVerifiedCore(UnsupportedVerifiedCore):
+    """The subject failed typed admission before SMT generation."""
+
+
+def generate_typed_smtlib(value: Any) -> str:
+    try:
+        document = validate_typed_document(value)
+    except (ValueError, TypeError, KeyError) as exc:
+        raise UnsupportedTypedVerifiedCore(str(exc)) from exc
+    return generate_smtlib(document)
+
+
+def generate_typed_smtlib_file(subject_path: Path, output_path: Path) -> int:
+    rendered = generate_typed_smtlib(load_json(subject_path))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered, encoding="utf-8")
+    return rendered.count("(check-sat)")
+
+
+__all__ = [
+    "UnsupportedTypedVerifiedCore",
+    "generate_typed_smtlib",
+    "generate_typed_smtlib_file",
+]

--- a/scripts/proof/typed_corehir_convert.py
+++ b/scripts/proof/typed_corehir_convert.py
@@ -1,0 +1,344 @@
+"""Fail-closed TypedCoreHIR v1 to VerifiedCore v1 conversion."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from proof.common import array_value, exact_keys, int_value, object_value, string_value, validate_header
+from proof.verified_core import validate_document as validate_verified_core
+
+SOURCE_SCHEMA = "arukellt-typed-corehir"
+SOURCE_VERSION = 1
+
+
+class UnsupportedTypedCoreHir(ValueError):
+    """Raised when a valid-looking TypedCoreHIR artifact is outside the conversion subset."""
+
+
+def _type_table(document: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[int, dict[str, Any]]]:
+    rendered: list[dict[str, Any]] = []
+    by_id: dict[int, dict[str, Any]] = {}
+    for index, raw in enumerate(array_value(document["types"], "$.types")):
+        path = f"$.types[{index}]"
+        entry = object_value(raw, path)
+        exact_keys(entry, path, required={"id", "kind", "name", "value_type", "representation"})
+        type_id = int_value(entry["id"], f"{path}.id", minimum=0)
+        if type_id in by_id:
+            raise UnsupportedTypedCoreHir(f"{path}.id: duplicate type id {type_id}")
+        kind = string_value(entry["kind"], f"{path}.kind")
+        name = string_value(entry["name"], f"{path}.name")
+        representation = object_value(entry["representation"], f"{path}.representation")
+        exact_keys(
+            representation,
+            f"{path}.representation",
+            required={"kind", "wasm", "nullable", "size_bytes", "align_bytes"},
+        )
+        verified_type: dict[str, Any] = {
+            "id": type_id,
+            "kind": kind,
+            "name": name,
+            "representation": {
+                "wasm": copy.deepcopy(representation["wasm"]),
+                "nullable": representation["nullable"],
+                "size_bytes": representation["size_bytes"],
+                "align_bytes": representation["align_bytes"],
+            },
+        }
+        if kind == "integer":
+            if name == "i32":
+                verified_type["bits"] = 32
+                verified_type["signed"] = True
+            elif name == "i64":
+                verified_type["bits"] = 64
+                verified_type["signed"] = True
+            else:
+                raise UnsupportedTypedCoreHir(f"{path}.name: unsupported integer type {name!r}")
+        elif kind not in {"unit", "bool"}:
+            raise UnsupportedTypedCoreHir(f"{path}.kind: unsupported proof type {kind!r}")
+        rendered.append(verified_type)
+        by_id[type_id] = entry
+    if not rendered:
+        raise UnsupportedTypedCoreHir("$.types: at least one type is required")
+    return rendered, by_id
+
+
+def _locals(function: dict[str, Any], path: str, known_types: set[int]) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    rendered: list[dict[str, Any]] = []
+    name_to_id: dict[str, int] = {}
+    for index, raw in enumerate(array_value(function["locals"], f"{path}.locals")):
+        local_path = f"{path}.locals[{index}]"
+        local = object_value(raw, local_path)
+        exact_keys(local, local_path, required={"id", "name", "type_id", "storage"})
+        local_id = int_value(local["id"], f"{local_path}.id", minimum=0)
+        name = string_value(local["name"], f"{local_path}.name")
+        type_id = int_value(local["type_id"], f"{local_path}.type_id", minimum=0)
+        if type_id not in known_types:
+            raise UnsupportedTypedCoreHir(f"{local_path}.type_id: unknown type {type_id}")
+        if name in name_to_id:
+            raise UnsupportedTypedCoreHir(f"{local_path}.name: duplicate local name {name!r}")
+        name_to_id[name] = local_id
+        rendered.append(
+            {
+                "id": local_id,
+                "name": name,
+                "type_id": type_id,
+                "storage": string_value(local["storage"], f"{local_path}.storage"),
+            }
+        )
+    return rendered, name_to_id
+
+
+def _expression_index(function: dict[str, Any], path: str) -> tuple[int, dict[int, dict[str, Any]]]:
+    body = object_value(function["body"], f"{path}.body")
+    exact_keys(body, f"{path}.body", required={"root_expr_id", "expressions"})
+    root = int_value(body["root_expr_id"], f"{path}.body.root_expr_id", minimum=0)
+    by_id: dict[int, dict[str, Any]] = {}
+    for index, raw in enumerate(array_value(body["expressions"], f"{path}.body.expressions")):
+        expr_path = f"{path}.body.expressions[{index}]"
+        expr = object_value(raw, expr_path)
+        exact_keys(
+            expr,
+            expr_path,
+            required={
+                "id",
+                "kind",
+                "kind_id",
+                "type_id",
+                "value_type",
+                "text",
+                "int_value",
+                "float_value",
+                "span_start",
+                "children",
+            },
+        )
+        expr_id = int_value(expr["id"], f"{expr_path}.id", minimum=0)
+        if expr_id in by_id:
+            raise UnsupportedTypedCoreHir(f"{expr_path}.id: duplicate expression id {expr_id}")
+        by_id[expr_id] = expr
+    if root not in by_id:
+        raise UnsupportedTypedCoreHir(f"{path}.body.root_expr_id: unknown expression {root}")
+    for expr_id, expr in by_id.items():
+        for child_index, child in enumerate(array_value(expr["children"], f"{path}.body.expressions[{expr_id}].children")):
+            child_id = int_value(child, f"{path}.body.expressions[{expr_id}].children[{child_index}]", minimum=0)
+            if child_id not in by_id:
+                raise UnsupportedTypedCoreHir(
+                    f"{path}.body.expressions[{expr_id}].children[{child_index}]: unknown expression {child_id}"
+                )
+    return root, by_id
+
+
+_BINARY_KINDS = {
+    "+": "add",
+    "-": "sub",
+    "*": "mul",
+    "/": "div",
+    "%": "mod",
+    "==": "eq",
+    "!=": "ne",
+    "<": "lt",
+    "<=": "le",
+    ">": "gt",
+    ">=": "ge",
+    "&&": "and",
+    "||": "or",
+}
+_UNARY_KINDS = {"!": "not", "-": "neg"}
+
+
+def _proof_expression(
+    expr_id: int,
+    expressions: dict[int, dict[str, Any]],
+    local_ids: dict[str, int],
+    result_name: str,
+    stack: set[int],
+    next_id: list[int],
+    path: str,
+) -> dict[str, Any]:
+    if expr_id in stack:
+        raise UnsupportedTypedCoreHir(f"{path}: expression cycle at {expr_id}")
+    stack = set(stack)
+    stack.add(expr_id)
+    expr = expressions[expr_id]
+    kind = string_value(expr["kind"], f"{path}.kind")
+    type_id = int_value(expr["type_id"], f"{path}.type_id", minimum=0)
+    text = expr["text"]
+    children = [int_value(value, f"{path}.children", minimum=0) for value in expr["children"]]
+    verified_id = next_id[0]
+    next_id[0] += 1
+    common: dict[str, Any] = {"id": verified_id, "type_id": type_id}
+
+    if kind in {"ident", "path"}:
+        name = string_value(text, f"{path}.text")
+        if result_name and name == result_name:
+            return {**common, "kind": "result"}
+        if name not in local_ids:
+            raise UnsupportedTypedCoreHir(f"{path}.text: unknown proof identifier {name!r}")
+        return {**common, "kind": "local", "local_id": local_ids[name]}
+    if kind == "int":
+        return {**common, "kind": "constant", "value": int_value(expr["int_value"], f"{path}.int_value")}
+    if kind == "bool":
+        normalized = str(text).lower()
+        if normalized not in {"true", "false"}:
+            raise UnsupportedTypedCoreHir(f"{path}.text: invalid boolean literal {text!r}")
+        return {**common, "kind": "constant", "value": normalized == "true"}
+    if kind == "binary":
+        operator = string_value(text, f"{path}.text")
+        verified_kind = _BINARY_KINDS.get(operator)
+        if verified_kind is None:
+            raise UnsupportedTypedCoreHir(f"{path}.text: unsupported binary operator {operator!r}")
+        if len(children) != 2:
+            raise UnsupportedTypedCoreHir(f"{path}.children: binary expression requires two children")
+        return {
+            **common,
+            "kind": verified_kind,
+            "operands": [
+                _proof_expression(children[0], expressions, local_ids, result_name, stack, next_id, f"{path}.children[0]"),
+                _proof_expression(children[1], expressions, local_ids, result_name, stack, next_id, f"{path}.children[1]"),
+            ],
+        }
+    if kind == "unary":
+        operator = string_value(text, f"{path}.text")
+        verified_kind = _UNARY_KINDS.get(operator)
+        if verified_kind is None:
+            raise UnsupportedTypedCoreHir(f"{path}.text: unsupported unary operator {operator!r}")
+        if len(children) != 1:
+            raise UnsupportedTypedCoreHir(f"{path}.children: unary expression requires one child")
+        return {
+            **common,
+            "kind": verified_kind,
+            "operands": [
+                _proof_expression(children[0], expressions, local_ids, result_name, stack, next_id, f"{path}.children[0]")
+            ],
+        }
+    raise UnsupportedTypedCoreHir(f"{path}.kind: unsupported proof expression kind {kind!r}")
+
+
+def _return_value(
+    root_id: int,
+    expressions: dict[int, dict[str, Any]],
+    contract_ids: set[int],
+    local_ids: dict[str, int],
+    path: str,
+) -> dict[str, Any]:
+    root = expressions[root_id]
+    candidates: list[int]
+    if root["kind"] == "block":
+        candidates = [int(child) for child in root["children"] if int(child) not in contract_ids]
+    else:
+        candidates = [root_id] if root_id not in contract_ids else []
+    if len(candidates) != 1:
+        raise UnsupportedTypedCoreHir(
+            f"{path}.body: expected exactly one non-contract return expression, found {len(candidates)}"
+        )
+    expr = expressions[candidates[0]]
+    type_id = int_value(expr["type_id"], f"{path}.body.return.type_id", minimum=0)
+    if expr["kind"] in {"ident", "path"}:
+        name = string_value(expr["text"], f"{path}.body.return.text")
+        if name not in local_ids:
+            raise UnsupportedTypedCoreHir(f"{path}.body.return.text: unknown local {name!r}")
+        return {"kind": "local", "type_id": type_id, "local_id": local_ids[name]}
+    if expr["kind"] == "int":
+        return {"kind": "constant", "type_id": type_id, "value": int(expr["int_value"])}
+    if expr["kind"] == "bool":
+        normalized = str(expr["text"]).lower()
+        if normalized not in {"true", "false"}:
+            raise UnsupportedTypedCoreHir(f"{path}.body.return.text: invalid boolean literal")
+        return {"kind": "constant", "type_id": type_id, "value": normalized == "true"}
+    raise UnsupportedTypedCoreHir(
+        f"{path}.body.return.kind: unsupported executable return expression {expr['kind']!r}"
+    )
+
+
+def convert_document(value: Any) -> dict[str, Any]:
+    source = object_value(value, "$")
+    validate_header(source, "$", SOURCE_SCHEMA, SOURCE_VERSION)
+    exact_keys(
+        source,
+        "$",
+        required={"schema", "schema_version", "generator", "module", "target_profile", "types", "functions"},
+    )
+    verified_types, source_types = _type_table(source)
+    known_types = set(source_types)
+    verified_functions: list[dict[str, Any]] = []
+
+    for function_index, raw in enumerate(array_value(source["functions"], "$.functions")):
+        path = f"$.functions[{function_index}]"
+        function = object_value(raw, path)
+        exact_keys(
+            function,
+            path,
+            required={"id", "name", "signature", "abi", "locals", "contracts", "body"},
+        )
+        rendered_locals, local_ids = _locals(function, path, known_types)
+        root_id, expressions = _expression_index(function, path)
+        contracts: list[dict[str, Any]] = []
+        contract_ids: set[int] = set()
+        next_proof_id = [0]
+        for contract_index, raw_contract in enumerate(array_value(function["contracts"], f"{path}.contracts")):
+            contract_path = f"{path}.contracts[{contract_index}]"
+            contract = object_value(raw_contract, contract_path)
+            exact_keys(contract, contract_path, required={"kind", "expression_id"}, optional={"result_name"})
+            kind = string_value(contract["kind"], f"{contract_path}.kind")
+            if kind not in {"requires", "ensures"}:
+                raise UnsupportedTypedCoreHir(f"{contract_path}.kind: unsupported contract {kind!r}")
+            expression_id = int_value(contract["expression_id"], f"{contract_path}.expression_id", minimum=0)
+            if expression_id not in expressions:
+                raise UnsupportedTypedCoreHir(f"{contract_path}.expression_id: unknown expression {expression_id}")
+            contract_ids.add(expression_id)
+            result_name = str(contract.get("result_name", "result" if kind == "ensures" else ""))
+            rendered: dict[str, Any] = {
+                "kind": kind,
+                "expression": _proof_expression(
+                    expression_id,
+                    expressions,
+                    local_ids,
+                    result_name,
+                    set(),
+                    next_proof_id,
+                    f"{contract_path}.expression",
+                ),
+            }
+            if result_name:
+                rendered["result_name"] = result_name
+            contracts.append(rendered)
+        if not contracts:
+            raise UnsupportedTypedCoreHir(f"{path}.contracts: at least one contract is required")
+
+        return_value = _return_value(root_id, expressions, contract_ids, local_ids, path)
+        verified_functions.append(
+            {
+                "id": function["id"],
+                "name": function["name"],
+                "signature": copy.deepcopy(function["signature"]),
+                "abi": copy.deepcopy(function["abi"]),
+                "locals": rendered_locals,
+                "contracts": contracts,
+                "body": {
+                    "entry_block": 0,
+                    "blocks": [
+                        {
+                            "id": 0,
+                            "parameters": [],
+                            "instructions": [],
+                            "terminator": {"kind": "return", "value": return_value},
+                        }
+                    ],
+                },
+            }
+        )
+
+    result = {
+        "schema": "arukellt-verified-core",
+        "schema_version": 1,
+        "generator": "arukellt-typed-corehir-converter-v1",
+        "module": source["module"],
+        "target_profile": copy.deepcopy(source["target_profile"]),
+        "types": verified_types,
+        "functions": verified_functions,
+    }
+    return validate_verified_core(result)
+
+
+__all__ = ["SOURCE_SCHEMA", "SOURCE_VERSION", "UnsupportedTypedCoreHir", "convert_document"]

--- a/scripts/proof/typed_corehir_typed_convert.py
+++ b/scripts/proof/typed_corehir_typed_convert.py
@@ -1,0 +1,205 @@
+"""Explicitly typed TypedCoreHIR v1 to VerifiedCore v1 conversion boundary.
+
+This v2 boundary requires logical integer metadata in the source artifact and
+normalizes the legacy converter input from that metadata. Source type names are
+preserved for identity and are never used to derive bits, signedness, ABI, or
+representation.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from proof.typed_corehir_convert import (
+    SOURCE_SCHEMA,
+    SOURCE_VERSION,
+    UnsupportedTypedCoreHir,
+    convert_document as convert_legacy_document,
+)
+from proof.verified_core_typed import validate_typed_document
+
+CONVERTER = "arukellt-typed-corehir-converter-v2"
+
+
+class ExplicitTypedCoreHirError(UnsupportedTypedCoreHir):
+    """TypedCoreHIR lacks explicit logical type information or is inconsistent."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ExplicitTypedCoreHirError(message)
+
+
+def _require_int(value: object, path: str, *, minimum: int = 0) -> int:
+    if type(value) is not int or int(value) < minimum:
+        raise ExplicitTypedCoreHirError(f"{path}: expected integer >= {minimum}")
+    return int(value)
+
+
+def _require_bool(value: object, path: str) -> bool:
+    if type(value) is not bool:
+        raise ExplicitTypedCoreHirError(f"{path}: expected boolean")
+    return bool(value)
+
+
+def _require_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ExplicitTypedCoreHirError(f"{path}: expected non-empty string")
+    return value
+
+
+def _validate_representation(
+    entry: dict[str, Any],
+    *,
+    path: str,
+    expected_value_type: str,
+    expected_wasm: list[str],
+    expected_size: int,
+) -> None:
+    value_type = _require_string(entry.get("value_type"), f"{path}.value_type")
+    _require(
+        value_type == expected_value_type,
+        f"{path}.value_type: expected {expected_value_type!r}, got {value_type!r}",
+    )
+    representation = entry.get("representation")
+    _require(isinstance(representation, dict), f"{path}.representation: expected object")
+    wasm = representation.get("wasm")
+    _require(wasm == expected_wasm, f"{path}.representation.wasm: explicit type mismatch")
+    _require(
+        representation.get("nullable") is False,
+        f"{path}.representation.nullable: scalar type must be non-nullable",
+    )
+    _require(
+        _require_int(representation.get("size_bytes"), f"{path}.representation.size_bytes")
+        == expected_size,
+        f"{path}.representation.size_bytes: explicit type mismatch",
+    )
+    align = _require_int(
+        representation.get("align_bytes"),
+        f"{path}.representation.align_bytes",
+        minimum=1,
+    )
+    _require(
+        align <= expected_size if expected_size else align == 1,
+        f"{path}.representation.align_bytes: invalid scalar alignment",
+    )
+
+
+def _normalize_types(source: dict[str, Any]) -> tuple[dict[str, Any], dict[int, dict[str, Any]]]:
+    raw_types = source.get("types")
+    _require(isinstance(raw_types, list) and raw_types, "$.types: expected non-empty array")
+    normalized = copy.deepcopy(source)
+    normalized_types: list[dict[str, Any]] = []
+    explicit_by_id: dict[int, dict[str, Any]] = {}
+
+    for index, raw in enumerate(raw_types):
+        path = f"$.types[{index}]"
+        _require(isinstance(raw, dict), f"{path}: expected object")
+        type_id = _require_int(raw.get("id"), f"{path}.id")
+        _require(type_id not in explicit_by_id, f"{path}.id: duplicate type id {type_id}")
+        kind = _require_string(raw.get("kind"), f"{path}.kind")
+        _require_string(raw.get("name"), f"{path}.name")
+        explicit = copy.deepcopy(raw)
+        legacy = {
+            key: copy.deepcopy(raw[key])
+            for key in ("id", "kind", "name", "value_type", "representation")
+            if key in raw
+        }
+
+        if kind == "integer":
+            _require(
+                set(raw) == {
+                    "id", "kind", "name", "bits", "signed", "value_type", "representation"
+                },
+                f"{path}: integer type requires explicit bits and signed fields",
+            )
+            bits = _require_int(raw.get("bits"), f"{path}.bits", minimum=1)
+            signed = _require_bool(raw.get("signed"), f"{path}.signed")
+            _require(signed and bits in {32, 64}, f"{path}: only explicit signed i32/i64 are supported")
+            expected = f"i{bits}"
+            _validate_representation(
+                raw,
+                path=path,
+                expected_value_type=expected,
+                expected_wasm=[expected],
+                expected_size=bits // 8,
+            )
+            # The legacy implementation receives a canonical internal name
+            # derived from explicit metadata, never the source identity name.
+            legacy["name"] = expected
+        elif kind == "bool":
+            _require(
+                set(raw) == {"id", "kind", "name", "value_type", "representation"},
+                f"{path}: bool type contains unsupported inferred metadata",
+            )
+            _validate_representation(
+                raw,
+                path=path,
+                expected_value_type="i32",
+                expected_wasm=["i32"],
+                expected_size=4,
+            )
+        elif kind == "unit":
+            _require(
+                set(raw) == {"id", "kind", "name", "value_type", "representation"},
+                f"{path}: unit type contains unsupported inferred metadata",
+            )
+            _validate_representation(
+                raw,
+                path=path,
+                expected_value_type="void",
+                expected_wasm=[],
+                expected_size=0,
+            )
+        else:
+            raise ExplicitTypedCoreHirError(
+                f"{path}.kind: unsupported explicit proof type {kind!r}"
+            )
+
+        explicit_by_id[type_id] = explicit
+        normalized_types.append(legacy)
+
+    normalized["types"] = normalized_types
+    return normalized, explicit_by_id
+
+
+def convert_typed_document(value: Any) -> dict[str, Any]:
+    _require(isinstance(value, dict), "$: expected object")
+    source = copy.deepcopy(value)
+    _require(source.get("schema") == SOURCE_SCHEMA, f"$.schema: expected {SOURCE_SCHEMA!r}")
+    _require(source.get("schema_version") == SOURCE_VERSION, f"$.schema_version: expected {SOURCE_VERSION}")
+
+    normalized, explicit_types = _normalize_types(source)
+    try:
+        converted = convert_legacy_document(normalized)
+    except UnsupportedTypedCoreHir as exc:
+        raise ExplicitTypedCoreHirError(str(exc)) from exc
+    converted_by_id = {int(entry["id"]): entry for entry in converted["types"]}
+    _require(set(converted_by_id) == set(explicit_types), "$.types: converted type set changed")
+
+    for type_id, explicit in explicit_types.items():
+        rendered = converted_by_id[type_id]
+        rendered["name"] = explicit["name"]
+        if explicit["kind"] == "integer":
+            rendered["bits"] = explicit["bits"]
+            rendered["signed"] = explicit["signed"]
+        _require(
+            rendered["representation"] == {
+                "wasm": explicit["representation"]["wasm"],
+                "nullable": explicit["representation"]["nullable"],
+                "size_bytes": explicit["representation"]["size_bytes"],
+                "align_bytes": explicit["representation"]["align_bytes"],
+            },
+            f"$.types[{type_id}].representation: converter changed explicit representation",
+        )
+
+    converted["generator"] = CONVERTER
+    return validate_typed_document(converted)
+
+
+__all__ = [
+    "CONVERTER",
+    "ExplicitTypedCoreHirError",
+    "convert_typed_document",
+]

--- a/scripts/proof/typed_verified_core_receipt.py
+++ b/scripts/proof/typed_verified_core_receipt.py
@@ -1,0 +1,119 @@
+"""Independent validator for typed VerifiedCore boundary evidence."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from proof.common import sha256_file
+
+SCHEMA = "arukellt-typed-verified-core-boundary"
+VERSION = 1
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+REQUIRED_SEMANTIC_CHECKS = {
+    "operator-arity-and-TypeId-preservation",
+    "contract-root-typing",
+    "result-return-TypeId-equality",
+    "parameter-signature-local-bijection",
+    "constant-payload-typing",
+    "global-contract-expression-id-uniqueness",
+    "semantic-admission-before-SMT",
+}
+
+
+class TypedVerifiedCoreReceiptError(ValueError):
+    """Typed VerifiedCore boundary evidence is malformed or stale."""
+
+
+def validate_boundary_receipt(
+    value: Any,
+    *,
+    root: Path | None = None,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypedVerifiedCoreReceiptError("receipt must be an object")
+    expected = {
+        "schema",
+        "schema_version",
+        "status",
+        "source_schema",
+        "target_schema",
+        "converter",
+        "logical_integer_metadata",
+        "type_name_semantics",
+        "structural_validator",
+        "semantic_validator",
+        "solver_adapter",
+        "semantic_checks",
+        "failure_action",
+        "files",
+    }
+    if set(value) != expected:
+        raise TypedVerifiedCoreReceiptError("receipt fields mismatch")
+    if value.get("schema") != SCHEMA or value.get("schema_version") != VERSION:
+        raise TypedVerifiedCoreReceiptError("receipt schema identity mismatch")
+    required_values = {
+        "status": "enforced",
+        "source_schema": "arukellt-typed-corehir@1",
+        "target_schema": "arukellt-verified-core@1",
+        "converter": "arukellt-typed-corehir-converter-v2",
+        "logical_integer_metadata": "explicit-bits-and-signedness",
+        "type_name_semantics": "identity-only",
+        "structural_validator": "verified_core.py@1",
+        "semantic_validator": "verified_core_typed.py@1",
+        "solver_adapter": "smtlib_typed_v1.py@1",
+        "failure_action": "reject-before-SMT-generation",
+    }
+    for field, expected_value in required_values.items():
+        if value.get(field) != expected_value:
+            raise TypedVerifiedCoreReceiptError(
+                f"{field}: expected {expected_value!r}, got {value.get(field)!r}"
+            )
+
+    checks = value.get("semantic_checks")
+    if not isinstance(checks, list) or any(not isinstance(item, str) for item in checks):
+        raise TypedVerifiedCoreReceiptError("semantic_checks must be a string array")
+    if set(checks) != REQUIRED_SEMANTIC_CHECKS or len(checks) != len(REQUIRED_SEMANTIC_CHECKS):
+        raise TypedVerifiedCoreReceiptError("semantic_checks set mismatch")
+
+    files = value.get("files")
+    if not isinstance(files, list) or not files:
+        raise TypedVerifiedCoreReceiptError("files must be a non-empty array")
+    seen: set[str] = set()
+    for index, entry in enumerate(files):
+        if not isinstance(entry, dict) or set(entry) != {"path", "sha256"}:
+            raise TypedVerifiedCoreReceiptError(f"files[{index}]: invalid entry")
+        relative = entry.get("path")
+        digest = entry.get("sha256")
+        if not isinstance(relative, str) or not relative:
+            raise TypedVerifiedCoreReceiptError(f"files[{index}].path: invalid path")
+        candidate = Path(relative)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise TypedVerifiedCoreReceiptError(
+                f"files[{index}].path: expected repository-relative path"
+            )
+        if relative in seen:
+            raise TypedVerifiedCoreReceiptError(f"files[{index}].path: duplicate path")
+        seen.add(relative)
+        if not isinstance(digest, str) or not _SHA256.fullmatch(digest):
+            raise TypedVerifiedCoreReceiptError(f"files[{index}].sha256: invalid digest")
+        if root is not None:
+            path = root / candidate
+            if not path.is_file():
+                raise TypedVerifiedCoreReceiptError(f"files[{index}].path: file missing")
+            actual = sha256_file(path)
+            if actual != digest:
+                raise TypedVerifiedCoreReceiptError(
+                    f"files[{index}].sha256: digest mismatch for {relative}"
+                )
+    return value
+
+
+__all__ = [
+    "REQUIRED_SEMANTIC_CHECKS",
+    "SCHEMA",
+    "VERSION",
+    "TypedVerifiedCoreReceiptError",
+    "validate_boundary_receipt",
+]

--- a/scripts/proof/verified_core_typed.py
+++ b/scripts/proof/verified_core_typed.py
@@ -1,0 +1,240 @@
+"""Independent semantic type validation for VerifiedCore v1.
+
+The structural validator proves schema/reference integrity. This validator proves
+that every accepted expression, contract, parameter local, and return value is
+well typed without reconstructing types from names or operator text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from proof.verified_core import validate_document
+
+SCHEMA = "arukellt-typed-verified-core-admission"
+VERSION = 1
+
+
+class TypedVerifiedCoreError(ValueError):
+    """VerifiedCore is structurally valid but violates typed semantics."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise TypedVerifiedCoreError(message)
+
+
+def _type_kinds(document: dict[str, Any]) -> dict[int, str]:
+    return {int(entry["id"]): str(entry["kind"]) for entry in document["types"]}
+
+
+def _check_constant(value: object, type_id: int, kinds: dict[int, str], path: str) -> None:
+    kind = kinds[type_id]
+    if kind == "bool":
+        _require(type(value) is bool, f"{path}: bool constant requires a boolean value")
+        return
+    if kind == "integer":
+        _require(type(value) is int, f"{path}: integer constant requires an integer value")
+        return
+    raise TypedVerifiedCoreError(
+        f"{path}: constants of type kind {kind!r} are outside typed VerifiedCore v1"
+    )
+
+
+def _expression_type(
+    expression: dict[str, Any],
+    *,
+    path: str,
+    kinds: dict[int, str],
+    local_types: dict[int, int],
+    return_type: int,
+    allow_result: bool,
+    seen_ids: set[int],
+) -> int:
+    expression_id = int(expression["id"])
+    if expression_id in seen_ids:
+        raise TypedVerifiedCoreError(f"{path}.id: duplicate expression id {expression_id}")
+    seen_ids.add(expression_id)
+
+    kind = str(expression["kind"])
+    type_id = int(expression["type_id"])
+    operands = expression.get("operands", [])
+    _require(isinstance(operands, list), f"{path}.operands: expected array")
+
+    if kind == "local":
+        _require(set(expression) <= {"id", "kind", "type_id", "local_id", "operands"},
+                 f"{path}: local expression has unsupported fields")
+        _require(not operands, f"{path}.operands: local expression must be a leaf")
+        local_id = expression.get("local_id")
+        _require(type(local_id) is int and local_id in local_types,
+                 f"{path}.local_id: unknown local {local_id!r}")
+        _require(local_types[int(local_id)] == type_id,
+                 f"{path}.type_id: local expression type does not match declaration")
+        return type_id
+
+    if kind == "result":
+        _require(set(expression) <= {"id", "kind", "type_id", "operands"},
+                 f"{path}: result expression has unsupported fields")
+        _require(allow_result, f"{path}: result is only valid in ensures contracts")
+        _require(not operands, f"{path}.operands: result expression must be a leaf")
+        _require(return_type != 0, f"{path}: unit-returning function has no result value")
+        _require(type_id == return_type,
+                 f"{path}.type_id: result type does not match function return type")
+        return type_id
+
+    if kind == "constant":
+        _require(set(expression) <= {"id", "kind", "type_id", "value", "operands"},
+                 f"{path}: constant expression has unsupported fields")
+        _require(not operands, f"{path}.operands: constant expression must be a leaf")
+        _require("value" in expression, f"{path}.value: constant value is required")
+        _check_constant(expression["value"], type_id, kinds, f"{path}.value")
+        return type_id
+
+    unary = {"neg", "not"}
+    binary = {"add", "sub", "mul", "div", "mod", "eq", "ne", "lt", "le", "gt", "ge", "and", "or"}
+    if kind not in unary | binary:
+        raise TypedVerifiedCoreError(
+            f"{path}.kind: unsupported typed expression kind {kind!r}"
+        )
+    _require(set(expression) <= {"id", "kind", "type_id", "operands"},
+             f"{path}: operator expression has unsupported fields")
+    expected_arity = 1 if kind in unary else 2
+    _require(len(operands) == expected_arity,
+             f"{path}.operands: {kind} requires {expected_arity} operand(s)")
+    operand_types = [
+        _expression_type(
+            operand,
+            path=f"{path}.operands[{index}]",
+            kinds=kinds,
+            local_types=local_types,
+            return_type=return_type,
+            allow_result=allow_result,
+            seen_ids=seen_ids,
+        )
+        for index, operand in enumerate(operands)
+    ]
+
+    if kind == "neg":
+        _require(kinds[operand_types[0]] == "integer", f"{path}: neg operand must be integer")
+        _require(type_id == operand_types[0], f"{path}.type_id: neg must preserve operand type")
+        return type_id
+    if kind == "not":
+        _require(kinds[operand_types[0]] == "bool", f"{path}: not operand must be bool")
+        _require(kinds[type_id] == "bool", f"{path}.type_id: not result must be bool")
+        return type_id
+
+    left, right = operand_types
+    _require(left == right, f"{path}.operands: binary operands must have identical TypeId")
+    operand_kind = kinds[left]
+    if kind in {"add", "sub", "mul", "div", "mod"}:
+        _require(operand_kind == "integer", f"{path}: arithmetic operands must be integer")
+        _require(type_id == left, f"{path}.type_id: arithmetic must preserve operand TypeId")
+    elif kind in {"lt", "le", "gt", "ge"}:
+        _require(operand_kind == "integer", f"{path}: ordered comparison operands must be integer")
+        _require(kinds[type_id] == "bool", f"{path}.type_id: comparison result must be bool")
+    elif kind in {"eq", "ne"}:
+        _require(operand_kind in {"integer", "bool"},
+                 f"{path}: equality operands must be integer or bool")
+        _require(kinds[type_id] == "bool", f"{path}.type_id: equality result must be bool")
+    else:
+        _require(operand_kind == "bool", f"{path}: logical operands must be bool")
+        _require(kinds[type_id] == "bool", f"{path}.type_id: logical result must be bool")
+    return type_id
+
+
+def _validate_parameter_locals(function: dict[str, Any], path: str) -> dict[int, int]:
+    signature_parameters = function["signature"]["parameters"]
+    locals_raw = function["locals"]
+    local_types: dict[int, int] = {}
+    local_names: dict[str, dict[str, Any]] = {}
+    for index, local in enumerate(locals_raw):
+        name = str(local["name"])
+        if name in local_names:
+            raise TypedVerifiedCoreError(f"{path}.locals[{index}].name: duplicate local {name!r}")
+        local_names[name] = local
+        local_types[int(local["id"])] = int(local["type_id"])
+
+    parameter_names = {str(parameter["name"]) for parameter in signature_parameters}
+    for index, parameter in enumerate(signature_parameters):
+        name = str(parameter["name"])
+        local = local_names.get(name)
+        _require(local is not None,
+                 f"{path}.signature.parameters[{index}]: no corresponding parameter local")
+        _require(local["storage"] == "parameter",
+                 f"{path}.locals: signature parameter {name!r} is not storage=parameter")
+        _require(int(local["type_id"]) == int(parameter["type_id"]),
+                 f"{path}.locals: parameter local {name!r} has a different TypeId")
+    for index, local in enumerate(locals_raw):
+        if local["storage"] == "parameter":
+            _require(str(local["name"]) in parameter_names,
+                     f"{path}.locals[{index}]: parameter local is absent from signature")
+    return local_types
+
+
+def _validate_return_value(
+    value: dict[str, Any],
+    *,
+    path: str,
+    return_type: int,
+    kinds: dict[int, str],
+    local_types: dict[int, int],
+) -> None:
+    type_id = int(value["type_id"])
+    _require(type_id == return_type, f"{path}.type_id: return value type mismatch")
+    kind = str(value["kind"])
+    if kind == "local":
+        local_id = int(value["local_id"])
+        _require(local_types.get(local_id) == type_id,
+                 f"{path}.local_id: return local type mismatch")
+    elif kind == "constant":
+        _check_constant(value["value"], type_id, kinds, f"{path}.value")
+    else:
+        raise TypedVerifiedCoreError(f"{path}.kind: unsupported return value kind {kind!r}")
+
+
+def validate_typed_document(value: Any) -> dict[str, Any]:
+    document = validate_document(value)
+    kinds = _type_kinds(document)
+    for function_index, function in enumerate(document["functions"]):
+        path = f"$.functions[{function_index}]"
+        return_type = int(function["signature"]["return_type_id"])
+        local_types = _validate_parameter_locals(function, path)
+        expression_ids: set[int] = set()
+        for contract_index, contract in enumerate(function["contracts"]):
+            contract_path = f"{path}.contracts[{contract_index}]"
+            contract_kind = str(contract["kind"])
+            expression_type = _expression_type(
+                contract["expression"],
+                path=f"{contract_path}.expression",
+                kinds=kinds,
+                local_types=local_types,
+                return_type=return_type,
+                allow_result=contract_kind == "ensures",
+                seen_ids=expression_ids,
+            )
+            if contract_kind == "decreases":
+                _require(kinds[expression_type] == "integer",
+                         f"{contract_path}.expression: decreases must be integer")
+            else:
+                _require(kinds[expression_type] == "bool",
+                         f"{contract_path}.expression: contract must have type bool")
+
+        for block_index, block in enumerate(function["body"]["blocks"]):
+            terminator = block["terminator"]
+            if terminator["kind"] == "return" and "value" in terminator:
+                _validate_return_value(
+                    terminator["value"],
+                    path=f"{path}.body.blocks[{block_index}].terminator.value",
+                    return_type=return_type,
+                    kinds=kinds,
+                    local_types=local_types,
+                )
+    return document
+
+
+__all__ = [
+    "SCHEMA",
+    "VERSION",
+    "TypedVerifiedCoreError",
+    "validate_typed_document",
+]

--- a/scripts/tests/test_smtlib_typed_v1.py
+++ b/scripts/tests/test_smtlib_typed_v1.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.smtlib_typed_v1 import (  # noqa: E402
+    UnsupportedTypedVerifiedCore,
+    generate_typed_smtlib,
+)
+from proof.typed_corehir_typed_convert import convert_typed_document  # noqa: E402
+
+
+class TypedSmtLibTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        source = json.loads(
+            (ROOT / "tests" / "proof" / "typed-corehir.json").read_text()
+        )
+        cls.document = convert_typed_document(source)
+
+    def test_generates_after_typed_admission(self) -> None:
+        rendered = generate_typed_smtlib(copy.deepcopy(self.document))
+        self.assertIn("(set-logic QF_LIA)", rendered)
+        self.assertIn("(check-sat)", rendered)
+
+    def test_rejects_operator_type_mismatch_before_rendering(self) -> None:
+        document = copy.deepcopy(self.document)
+        expression = document["functions"][0]["contracts"][0]["expression"]
+        expression["kind"] = "add"
+        with self.assertRaisesRegex(
+            UnsupportedTypedVerifiedCore,
+            "arithmetic must preserve operand TypeId",
+        ):
+            generate_typed_smtlib(document)
+
+    def test_rejects_parameter_local_mismatch_before_rendering(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["functions"][0]["locals"][0]["storage"] = "local"
+        with self.assertRaisesRegex(
+            UnsupportedTypedVerifiedCore,
+            "not storage=parameter",
+        ):
+            generate_typed_smtlib(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_typed_corehir_convert.py
+++ b/scripts/tests/test_typed_corehir_convert.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.typed_corehir_typed_convert import (  # noqa: E402
+    ExplicitTypedCoreHirError,
+    convert_typed_document,
+)
+
+
+class TypedCoreHirConvertTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = json.loads(
+            (ROOT / "tests" / "proof" / "typed-corehir.json").read_text()
+        )
+
+    def test_identity_converts_to_structured_typed_verified_core(self) -> None:
+        converted = convert_typed_document(copy.deepcopy(self.source))
+        function = converted["functions"][0]
+        self.assertEqual(converted["schema"], "arukellt-verified-core")
+        self.assertEqual(converted["generator"], "arukellt-typed-corehir-converter-v2")
+        self.assertEqual(
+            function["body"]["blocks"][0]["terminator"]["value"],
+            {"kind": "local", "type_id": 1, "local_id": 0},
+        )
+        expression = function["contracts"][0]["expression"]
+        self.assertEqual(expression["kind"], "ge")
+        self.assertEqual(expression["operands"][0]["kind"], "local")
+        self.assertEqual(expression["operands"][1]["kind"], "local")
+
+    def test_integer_name_is_identity_not_type_inference(self) -> None:
+        converted = convert_typed_document(copy.deepcopy(self.source))
+        integer = next(entry for entry in converted["types"] if entry["id"] == 1)
+        self.assertEqual(integer["name"], "ApplicationCounter")
+        self.assertEqual(integer["bits"], 32)
+        self.assertIs(integer["signed"], True)
+        self.assertEqual(integer["representation"]["wasm"], ["i32"])
+
+    def test_result_identifier_converts_to_result_node(self) -> None:
+        document = copy.deepcopy(self.source)
+        function = document["functions"][0]
+        function["body"]["expressions"].append(
+            {
+                "id": 3,
+                "kind": "ident",
+                "kind_id": 5,
+                "type_id": 1,
+                "value_type": "i32",
+                "text": "result",
+                "int_value": 0,
+                "float_value": 0.0,
+                "span_start": 3,
+                "children": [],
+            }
+        )
+        function["body"]["expressions"][2]["children"] = [3, 1]
+        converted = convert_typed_document(document)
+        expression = converted["functions"][0]["contracts"][0]["expression"]
+        self.assertEqual(expression["operands"][0]["kind"], "result")
+
+    def test_missing_integer_metadata_fails_closed(self) -> None:
+        document = copy.deepcopy(self.source)
+        integer = document["types"][1]
+        integer.pop("bits")
+        with self.assertRaisesRegex(
+            ExplicitTypedCoreHirError,
+            "requires explicit bits and signed",
+        ):
+            convert_typed_document(document)
+
+    def test_integer_representation_mismatch_fails_closed(self) -> None:
+        document = copy.deepcopy(self.source)
+        document["types"][1]["representation"]["wasm"] = ["i64"]
+        with self.assertRaisesRegex(ExplicitTypedCoreHirError, "explicit type mismatch"):
+            convert_typed_document(document)
+
+    def test_integer_value_type_mismatch_fails_closed(self) -> None:
+        document = copy.deepcopy(self.source)
+        document["types"][1]["value_type"] = "i64"
+        with self.assertRaisesRegex(ExplicitTypedCoreHirError, "expected 'i32'"):
+            convert_typed_document(document)
+
+    def test_multiple_executable_body_children_fail_closed(self) -> None:
+        document = copy.deepcopy(self.source)
+        function = document["functions"][0]
+        function["body"]["root_expr_id"] = 0
+        function["body"]["expressions"][0]["children"] = [1, 1, 2]
+        with self.assertRaisesRegex(
+            ExplicitTypedCoreHirError,
+            "exactly one non-contract return",
+        ):
+            convert_typed_document(document)
+
+    def test_unknown_contract_identifier_fails_closed(self) -> None:
+        document = copy.deepcopy(self.source)
+        function = document["functions"][0]
+        function["body"]["expressions"][1]["text"] = "missing"
+        with self.assertRaisesRegex(ExplicitTypedCoreHirError, "unknown proof identifier"):
+            convert_typed_document(document)
+
+    def test_reference_type_fails_closed(self) -> None:
+        document = copy.deepcopy(self.source)
+        document["types"].append(
+            {
+                "id": 3,
+                "kind": "reference",
+                "name": "String",
+                "value_type": "gc-ref",
+                "representation": {
+                    "kind": "gc-ref",
+                    "wasm": ["gc-ref"],
+                    "nullable": True,
+                    "size_bytes": 4,
+                    "align_bytes": 4,
+                },
+            }
+        )
+        with self.assertRaisesRegex(ExplicitTypedCoreHirError, "unsupported explicit proof type"):
+            convert_typed_document(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_typed_verified_core_receipt.py
+++ b/scripts/tests/test_typed_verified_core_receipt.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.typed_verified_core_receipt import (  # noqa: E402
+    REQUIRED_SEMANTIC_CHECKS,
+    TypedVerifiedCoreReceiptError,
+    validate_boundary_receipt,
+)
+
+
+class TypedVerifiedCoreReceiptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.bound = self.root / "validator.py"
+        self.bound.write_text("validator\n", encoding="utf-8")
+        digest = hashlib.sha256(self.bound.read_bytes()).hexdigest()
+        self.document = {
+            "schema": "arukellt-typed-verified-core-boundary",
+            "schema_version": 1,
+            "status": "enforced",
+            "source_schema": "arukellt-typed-corehir@1",
+            "target_schema": "arukellt-verified-core@1",
+            "converter": "arukellt-typed-corehir-converter-v2",
+            "logical_integer_metadata": "explicit-bits-and-signedness",
+            "type_name_semantics": "identity-only",
+            "structural_validator": "verified_core.py@1",
+            "semantic_validator": "verified_core_typed.py@1",
+            "solver_adapter": "smtlib_typed_v1.py@1",
+            "semantic_checks": sorted(REQUIRED_SEMANTIC_CHECKS),
+            "failure_action": "reject-before-SMT-generation",
+            "files": [{"path": "validator.py", "sha256": digest}],
+        }
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_accepts_complete_hash_bound_receipt(self) -> None:
+        validated = validate_boundary_receipt(copy.deepcopy(self.document), root=self.root)
+        self.assertEqual(validated["status"], "enforced")
+
+    def test_rejects_stale_file_digest(self) -> None:
+        self.bound.write_text("changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(TypedVerifiedCoreReceiptError, "digest mismatch"):
+            validate_boundary_receipt(copy.deepcopy(self.document), root=self.root)
+
+    def test_rejects_missing_semantic_check(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["semantic_checks"].pop()
+        with self.assertRaisesRegex(TypedVerifiedCoreReceiptError, "semantic_checks set mismatch"):
+            validate_boundary_receipt(document, root=self.root)
+
+    def test_rejects_duplicate_bound_path(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["files"].append(copy.deepcopy(document["files"][0]))
+        with self.assertRaisesRegex(TypedVerifiedCoreReceiptError, "duplicate path"):
+            validate_boundary_receipt(document, root=self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_verified_core_typed.py
+++ b/scripts/tests/test_verified_core_typed.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.typed_corehir_typed_convert import convert_typed_document  # noqa: E402
+from proof.verified_core_typed import (  # noqa: E402
+    TypedVerifiedCoreError,
+    validate_typed_document,
+)
+
+
+class TypedVerifiedCoreTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        source = json.loads(
+            (ROOT / "tests" / "proof" / "typed-corehir.json").read_text()
+        )
+        cls.document = convert_typed_document(source)
+
+    def validate(self, document: dict[str, object]) -> dict[str, object]:
+        return validate_typed_document(copy.deepcopy(document))
+
+    def test_accepts_semantically_typed_conversion(self) -> None:
+        validated = self.validate(self.document)
+        self.assertEqual(validated["schema"], "arukellt-verified-core")
+
+    def test_contract_root_must_be_bool(self) -> None:
+        document = copy.deepcopy(self.document)
+        expression = document["functions"][0]["contracts"][0]["expression"]
+        expression["kind"] = "add"
+        expression["type_id"] = 1
+        with self.assertRaisesRegex(TypedVerifiedCoreError, "contract must have type bool"):
+            self.validate(document)
+
+    def test_arithmetic_cannot_claim_bool_result(self) -> None:
+        document = copy.deepcopy(self.document)
+        expression = document["functions"][0]["contracts"][0]["expression"]
+        expression["kind"] = "add"
+        with self.assertRaisesRegex(TypedVerifiedCoreError, "arithmetic must preserve"):
+            self.validate(document)
+
+    def test_logical_operator_rejects_integer_operands(self) -> None:
+        document = copy.deepcopy(self.document)
+        expression = document["functions"][0]["contracts"][0]["expression"]
+        expression["kind"] = "and"
+        with self.assertRaisesRegex(TypedVerifiedCoreError, "logical operands must be bool"):
+            self.validate(document)
+
+    def test_result_type_must_match_function_return(self) -> None:
+        document = copy.deepcopy(self.document)
+        expression = document["functions"][0]["contracts"][0]["expression"]
+        expression["operands"][0] = {
+            "id": 100,
+            "kind": "result",
+            "type_id": 2,
+        }
+        with self.assertRaisesRegex(TypedVerifiedCoreError, "result type does not match"):
+            self.validate(document)
+
+    def test_result_is_rejected_outside_ensures(self) -> None:
+        document = copy.deepcopy(self.document)
+        contract = document["functions"][0]["contracts"][0]
+        contract["kind"] = "requires"
+        contract.pop("result_name", None)
+        contract["expression"]["operands"][0] = {
+            "id": 100,
+            "kind": "result",
+            "type_id": 1,
+        }
+        with self.assertRaisesRegex(TypedVerifiedCoreError, "only valid in ensures"):
+            self.validate(document)
+
+    def test_signature_parameter_requires_matching_parameter_local(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["functions"][0]["locals"][0]["storage"] = "local"
+        with self.assertRaisesRegex(TypedVerifiedCoreError, "not storage=parameter"):
+            self.validate(document)
+
+    def test_parameter_local_cannot_be_absent_from_signature(self) -> None:
+        document = copy.deepcopy(self.document)
+        document["functions"][0]["signature"]["parameters"] = []
+        document["functions"][0]["abi"]["parameters"] = []
+        with self.assertRaisesRegex(TypedVerifiedCoreError, "absent from signature"):
+            self.validate(document)
+
+    def test_integer_constant_rejects_boolean_payload(self) -> None:
+        document = copy.deepcopy(self.document)
+        terminator = document["functions"][0]["body"]["blocks"][0]["terminator"]
+        terminator["value"] = {
+            "kind": "constant",
+            "type_id": 1,
+            "value": True,
+        }
+        with self.assertRaisesRegex(TypedVerifiedCoreError, "integer constant requires"):
+            self.validate(document)
+
+    def test_expression_ids_are_unique_across_contracts(self) -> None:
+        document = copy.deepcopy(self.document)
+        duplicate = copy.deepcopy(document["functions"][0]["contracts"][0])
+        document["functions"][0]["contracts"].append(duplicate)
+        with self.assertRaisesRegex(TypedVerifiedCoreError, "duplicate expression id"):
+            self.validate(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/proof/typed-corehir.json
+++ b/tests/proof/typed-corehir.json
@@ -26,7 +26,9 @@
     {
       "id": 1,
       "kind": "integer",
-      "name": "i32",
+      "name": "ApplicationCounter",
+      "bits": 32,
+      "signed": true,
       "value_type": "i32",
       "representation": {
         "kind": "scalar",


### PR DESCRIPTION
Supersedes #31 for stack integration.

This clean integration preserves the completed typed VerifiedCore boundary while rebasing it onto the current formal-verification integration branch. It retains all previously enabled proof-policy gates and restores SolverResult v1 output plus independent validation in every affected solver workflow.

Included:
- explicit TypedCoreHIR integer metadata boundary
- independent semantic VerifiedCore validator
- typed SMT adapter and bypass gate
- hash-bound typed-boundary receipt and validator
- negative tests and fixtures
- `typed_verified_core_emission=true`
- SolverResult-required workflow invocations from #26

No CI result is claimed.