### PR TITLE
feat(proof): integrate typed source contracts

### DIFF
--- a/.github/workflows/typed-contract-frontend.yml
+++ b/.github/workflows/typed-contract-frontend.yml
@@ -1,0 +1,223 @@
+name: Typed proof contract frontend
+
+on:
+  pull_request:
+    branches: [agent/formal-verification-hard-gates, master]
+  workflow_dispatch:
+
+concurrency:
+  group: typed-contract-frontend-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typed-contract-frontend:
+    name: "Typed proof contract frontend"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check structured and typed proof boundaries
+        run: |
+          python3 scripts/check/check-typed-contract-source.py
+          python3 scripts/check/check-typed-verified-core-boundary.py
+          python3 scripts/check/check-solver-trust-manifest-boundary.py
+
+      - name: Validate proof adapters
+        run: |
+          python3 -m unittest \
+            scripts.tests.test_proof_artifacts \
+            scripts.tests.test_typed_corehir_artifacts \
+            scripts.tests.test_typed_corehir_convert \
+            scripts.tests.test_source_contract_profile \
+            scripts.tests.test_source_proof_binding \
+            scripts.tests.test_verified_core_typed \
+            scripts.tests.test_smtlib_typed_v1 \
+            scripts.tests.test_solver_result \
+            scripts.tests.test_solver_driver
+
+      - name: Install Wasmtime and Z3
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.1
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+          sudo apt-get update
+          sudo apt-get install -y z3
+          z3 --version
+
+      - name: Build host linker
+        run: |
+          cargo build --release --quiet
+          cargo test --lib --no-run --quiet
+        working-directory: tools/host-linker
+
+      - name: Build current selfhost stage 2 runtime
+        run: |
+          python3 - <<'PY'
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, "scripts")
+          from selfhost.checks import rebuild_current_s2
+          path, error, elapsed = rebuild_current_s2(Path.cwd(), force=True)
+          if path is None:
+              raise SystemExit(error or "stage-2 build failed")
+          expected = Path(".build/selfhost/arukellt-s2-runtime.wasm").resolve()
+          if path.resolve() != expected:
+              raise SystemExit(f"unexpected stage-2 runtime path: {path}")
+          print(f"typed-contract-s2: PASS: path={path} elapsed={elapsed:.3f}s")
+          PY
+          test -s .build/selfhost/arukellt-s2-runtime.wasm
+
+      - name: Emit and validate typed source contracts
+        env:
+          ARUKELLT_SELFHOST_WASM: .build/selfhost/arukellt-s2-runtime.wasm
+        run: python3 scripts/check/check-typed-contract-emission.py
+
+      - name: Convert compiler artifact into typed proof VCs
+        run: |
+          python3 scripts/gen/convert-typed-corehir.py \
+            --input .build/typed-contract-proof/typed-corehir.json \
+            --output .build/typed-contract-proof/verified-core-machine.json
+          python3 scripts/check/check-typed-verified-core.py \
+            .build/typed-contract-proof/verified-core-machine.json
+          python3 scripts/gen/normalize-source-contract-profile.py \
+            --input .build/typed-contract-proof/verified-core-machine.json \
+            --output .build/typed-contract-proof/verified-core.json
+          python3 scripts/check/check-typed-verified-core.py \
+            .build/typed-contract-proof/verified-core.json
+          python3 scripts/gen/write-smt-vcs.py \
+            --subject .build/typed-contract-proof/verified-core.json \
+            --output .build/typed-contract-proof/verified-core-vcs.smt2
+          python3 scripts/gen/write-source-proof-binding.py \
+            --source tests/verified-core/contract_identity.ark \
+            --producer-executable .build/selfhost/arukellt-s2-runtime.wasm \
+            --typed-corehir .build/typed-contract-proof/typed-corehir.json \
+            --verified-core-machine .build/typed-contract-proof/verified-core-machine.json \
+            --verified-core-normalized .build/typed-contract-proof/verified-core.json \
+            --solver-input .build/typed-contract-proof/verified-core-vcs.smt2 \
+            --output .build/typed-contract-proof/source-proof-binding.json
+
+      - name: Build hash-bound typed proof toolchain
+        run: |
+          mkdir -p .build/typed-contract-toolchain
+          cp .build/selfhost/arukellt-s2-runtime.wasm .build/typed-contract-toolchain/arukellt-s2-runtime.wasm
+          cp "$(command -v z3)" .build/typed-contract-toolchain/z3
+          cp .build/typed-contract-proof/source-proof-binding.json .build/typed-contract-toolchain/source-proof-binding.json
+          cp scripts/proof/common.py .build/typed-contract-toolchain/common.py
+          cp scripts/proof/source_proof_binding.py .build/typed-contract-toolchain/source_proof_binding.py
+          cp scripts/proof/typed_corehir.py .build/typed-contract-toolchain/typed_corehir.py
+          cp scripts/proof/typed_corehir_impl.py .build/typed-contract-toolchain/typed_corehir_impl.py
+          cp scripts/proof/typed_corehir_typed_convert.py .build/typed-contract-toolchain/typed_corehir_typed_convert.py
+          cp scripts/proof/typed_corehir_convert.py .build/typed-contract-toolchain/typed_corehir_convert.py
+          cp scripts/proof/normalize_source_contract_profile.py .build/typed-contract-toolchain/normalize_source_contract_profile.py
+          cp scripts/proof/verified_core.py .build/typed-contract-toolchain/verified_core.py
+          cp scripts/proof/verified_core_typed.py .build/typed-contract-toolchain/verified_core_typed.py
+          cp scripts/proof/smtlib_typed_v1.py .build/typed-contract-toolchain/smtlib_typed_v1.py
+          cp scripts/proof/smtlib_v1.py .build/typed-contract-toolchain/smtlib_v1.py
+          python3 - <<'PY'
+          import json
+          import subprocess
+          from pathlib import Path
+          version = subprocess.check_output(["z3", "--version"], text=True).strip()
+          components = [
+              ("arukellt-source-proof-binding-v1", "source-artifact-binding", "1", "source-proof-binding.json"),
+              ("arukellt-source-proof-binding-validator-v1", "source-artifact-binding-validator", "1", "source_proof_binding.py"),
+              ("arukellt-typed-corehir-validator-v1", "typed-corehir-validator", "1", "typed_corehir.py"),
+              ("arukellt-typed-corehir-validator-impl-v1", "typed-corehir-validator-implementation", "1", "typed_corehir_impl.py"),
+              ("arukellt-typed-corehir-to-verified-core-v2", "typed-proof-boundary", "2", "typed_corehir_typed_convert.py"),
+              ("arukellt-typed-corehir-converter-implementation-v1", "typed-proof-boundary-implementation", "1", "typed_corehir_convert.py"),
+              ("arukellt-source-contract-profile-normalizer-v1", "semantic-profile-normalizer", "1", "normalize_source_contract_profile.py"),
+              ("arukellt-verified-core-structural-validator-v1", "artifact-validator", "1", "verified_core.py"),
+              ("arukellt-verified-core-semantic-validator-v1", "typed-artifact-validator", "1", "verified_core_typed.py"),
+              ("arukellt-typed-verified-core-smt-adapter-v1", "typed-smt-adapter", "1", "smtlib_typed_v1.py"),
+              ("arukellt-smt-renderer-v1", "smt-renderer-implementation", "1", "smtlib_v1.py"),
+          ]
+          document = {
+              "schema": "arukellt-proof-toolchain",
+              "schema_version": 1,
+              "producer": {
+                  "name": "arukellt-selfhost-typed-contract-emitter",
+                  "version": "current-s2-runtime",
+                  "executable": "arukellt-s2-runtime.wasm",
+                  "arguments": ["compile", "tests/verified-core/contract_identity.ark", "--emit", "typed-corehir"],
+              },
+              "translator": {
+                  "name": "arukellt-typed-verified-core-smtlib",
+                  "version": "1",
+                  "executable": "smtlib_typed_v1.py",
+              },
+              "solver": {
+                  "name": "z3",
+                  "version": version,
+                  "executable": "z3",
+                  "arguments": ["-in", "-smt2"],
+              },
+              "semantic_profile": {
+                  "integer_model": "mathematical",
+                  "overflow": "checked",
+                  "floating_point": "unsupported",
+                  "memory": "pure-values",
+              },
+              "assumptions": [],
+              "trusted_components": [
+                  {"name": name, "role": role, "version": version, "artifact": artifact}
+                  for name, role, version, artifact in components
+              ],
+              "limits": {"timeout_ms": 10000, "memory_bytes": 1073741824},
+          }
+          Path(".build/typed-contract-toolchain/toolchain.json").write_text(
+              json.dumps(document, indent=2) + "\n", encoding="utf-8"
+          )
+          PY
+
+      - name: Prove compiler-emitted contracts with Z3
+        run: |
+          python3 scripts/run/run-proof-solver.py \
+            --subject .build/typed-contract-proof/verified-core.json \
+            --solver-input .build/typed-contract-proof/verified-core-vcs.smt2 \
+            --toolchain .build/typed-contract-toolchain/toolchain.json \
+            --solver-output .build/typed-contract-proof/solver-output.txt \
+            --trust-manifest-output .build/typed-contract-proof/trust-manifest.json \
+            --proof-receipt-output .build/typed-contract-proof/proof-receipt.json \
+            --solver-result-output .build/typed-contract-proof/solver-result.json
+          python3 scripts/check/check-solver-result.py \
+            .build/typed-contract-proof/solver-result.json \
+            --subject .build/typed-contract-proof/verified-core.json \
+            --solver-input .build/typed-contract-proof/verified-core-vcs.smt2 \
+            --toolchain .build/typed-contract-toolchain/toolchain.json \
+            --solver-output .build/typed-contract-proof/solver-output.txt \
+            --trust-manifest .build/typed-contract-proof/trust-manifest.json \
+            --proof-receipt .build/typed-contract-proof/proof-receipt.json
+
+      - name: Verify source-to-result bindings
+        run: |
+          python3 - <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, "scripts")
+          from proof.source_proof_binding import validate_binding
+          proof = Path(".build/typed-contract-proof")
+          validate_binding(
+              json.loads((proof / "source-proof-binding.json").read_text()),
+              {
+                  "source": Path("tests/verified-core/contract_identity.ark"),
+                  "producer_executable": Path(".build/selfhost/arukellt-s2-runtime.wasm"),
+                  "typed_corehir": proof / "typed-corehir.json",
+                  "verified_core_machine": proof / "verified-core-machine.json",
+                  "verified_core_normalized": proof / "verified-core.json",
+                  "solver_input": proof / "verified-core-vcs.smt2",
+              },
+          )
+          result = json.loads((proof / "solver-result.json").read_text())
+          if result["status"] != "proved":
+              raise SystemExit(result)
+          print("typed-source-contract-proof: PASS")
+          PY
+
+      - name: Upload source proof bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: typed-source-contract-proof
+          path: |
+            .build/typed-contract-proof
+            .build/typed-contract-toolchain/toolchain.json
+          if-no-files-found: error

--- a/schemas/typed-corehir-v1.schema.json
+++ b/schemas/typed-corehir-v1.schema.json
@@ -49,9 +49,18 @@
         "id": {"type": "integer", "minimum": 0},
         "kind": {"enum": ["unit", "bool", "integer", "float", "string", "reference", "function", "vector"]},
         "name": {"type": "string", "minLength": 1, "pattern": "^(?!unknown$)(?!\\?).+"},
+        "bits": {"enum": [32, 64]},
+        "signed": {"const": true},
         "value_type": {"enum": ["void", "i32", "i64", "f32", "f64", "v128", "ref", "gc-ref", "funcref"]},
         "representation": {"$ref": "#/$defs/representation"}
-      }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"kind": {"const": "integer"}}, "required": ["kind"]},
+          "then": {"required": ["bits", "signed"]},
+          "else": {"not": {"anyOf": [{"required": ["bits"]}, {"required": ["signed"]}]}}
+        }
+      ]
     },
     "parameter": {
       "type": "object",

--- a/scripts/check/check-typed-contract-emission.py
+++ b/scripts/check/check-typed-contract-emission.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Exercise source proof contracts through selfhost TypedCoreHIR emission."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+OUTPUT = ROOT / ".build" / "typed-contract-proof" / "typed-corehir.json"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.typed_corehir import validate_document  # noqa: E402
+
+
+def compile_source(relative: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            str(ROOT / "scripts" / "run" / "arukellt-selfhost.sh"),
+            "compile",
+            relative,
+            "--emit",
+            "typed-corehir",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def emitted_artifact(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
+    candidates: list[dict[str, object]] = []
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("{"):
+            continue
+        try:
+            value = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if value.get("schema") == "arukellt-typed-corehir":
+            candidates.append(value)
+    if len(candidates) != 1:
+        raise ValueError(f"expected one TypedCoreHIR artifact, found {len(candidates)}")
+    return validate_document(candidates[0])
+
+
+def require_compile_failure(relative: str, diagnostic_fragment: str) -> None:
+    result = compile_source(relative)
+    if result.returncode == 0:
+        raise ValueError(f"{relative}: unexpectedly compiled")
+    diagnostic = result.stdout + "\n" + result.stderr
+    if diagnostic_fragment not in diagnostic:
+        raise ValueError(
+            f"{relative}: diagnostic {diagnostic_fragment!r} missing\n{diagnostic}"
+        )
+
+
+def main() -> int:
+    valid = compile_source("tests/verified-core/contract_identity.ark")
+    if valid.returncode != 0:
+        raise ValueError(
+            f"valid contract compile exited {valid.returncode}\n{valid.stdout}\n{valid.stderr}"
+        )
+    document = emitted_artifact(valid)
+    functions = document["functions"]
+    identity = next(
+        (
+            function
+            for function in functions
+            if str(function["name"]).endswith("identity")
+        ),
+        None,
+    )
+    if identity is None:
+        raise ValueError("identity function missing from TypedCoreHIR")
+    contracts = identity["contracts"]
+    if [contract["kind"] for contract in contracts] != ["requires", "ensures"]:
+        raise ValueError(f"unexpected contract kinds: {contracts}")
+    if contracts[1].get("result_name") != "result":
+        raise ValueError("ensures contract does not bind result")
+    expression_ids = {
+        expression["id"]
+        for expression in identity["body"]["expressions"]
+    }
+    for contract in contracts:
+        if contract["expression_id"] not in expression_ids:
+            raise ValueError(f"contract expression is not retained: {contract}")
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    require_compile_failure(
+        "tests/verified-core/contract_non_bool.ark",
+        "proof contract must have type bool",
+    )
+    require_compile_failure(
+        "tests/verified-core/contract_result_in_requires.ark",
+        "result is only available in ensures contracts",
+    )
+    require_compile_failure(
+        "tests/verified-core/contract_unknown_identifier.ark",
+        "unknown proof identifier: missing",
+    )
+
+    print(
+        "typed-contract-emission: PASS: "
+        f"contracts={len(contracts)} expressions={len(expression_ids)} output={OUTPUT}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, StopIteration, KeyError, TypeError) as exc:
+        print(f"typed-contract-emission: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/check/check-typed-contract-source.py
+++ b/scripts/check/check-typed-contract-source.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Check the structured typed-contract compiler boundary."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def require(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise ValueError(f"missing {label}: {needle}")
+
+
+def reject(text: str, needle: str, label: str) -> None:
+    if needle in text:
+        raise ValueError(f"forbidden {label}: {needle}")
+
+
+def main() -> int:
+    tokens = read("src/compiler/lexer/tokens.ark")
+    keywords = read("src/compiler/lexer/keywords_decl.ark")
+    parser = read("src/compiler/parser/proof_contracts.ark")
+    fn_sig = read("src/compiler/parser/fn_sig_decl.ark")
+    checker = read("src/compiler/typechecker/proof_contracts.ark")
+    body_checker = read("src/compiler/typechecker/body.ark")
+    body_table = read("src/compiler/corehir/body_table.ark")
+    body_roots = read("src/compiler/corehir/body_roots.ark")
+    renderer = read("src/compiler/driver/typed_corehir_contract_render.ark")
+    entry = read("src/compiler/driver/typed_corehir_render.ark")
+
+    require(tokens, "fn TK_PROOF()", "proof token")
+    require(keywords, 'eq(word, "proof")', "proof keyword")
+    require(parser, "AstNode_push_type_ann(node, contract)", "contract AST retention")
+    require(parser, "expr::parse_expr(p)", "structured expression parser")
+    require(fn_sig, "parse_proof_contract_block(p, node)", "function-header integration")
+
+    require(checker, "infer::infer_expr", "contract type inference")
+    require(checker, 'scope::scope_define(\n                contract_scope,\n                "result"', "ensures result binding")
+    require(checker, "proof contract must have type bool", "bool contract gate")
+    require(body_checker, "proof_contracts::check_proof_contracts", "body typecheck integration")
+
+    require(body_table, "contract_roots: Vec<i32>", "contract root storage")
+    require(body_table, "contract_kinds: Vec<String>", "contract kind storage")
+    require(body_roots, "corehir_build_expr(table, expression)", "typed CoreHIR contract lowering")
+    require(renderer, '"{\\\"kind\\\":"', "contract JSON rendering")
+    require(renderer, '\\"expression_id\\"', "contract expression identity")
+    require(renderer, "tccr_collect_reachable", "contract reachability integration")
+    require(entry, "typed_corehir_contract_render::render_function", "contract renderer entrypoint")
+
+    for text, label in (
+        (parser, "parser"),
+        (checker, "typechecker"),
+        (body_roots, "CoreHIR retention"),
+        (renderer, "TypedCoreHIR renderer"),
+    ):
+        reject(text, "S-expression", f"{label} string proof model")
+        reject(text, "sexpr", f"{label} S-expression proof model")
+
+    print("typed-contract-source: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"typed-contract-source: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/normalize-source-contract-profile.py
+++ b/scripts/gen/normalize-source-contract-profile.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Normalize comparison-only VerifiedCore emitted from source contracts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.normalize_source_contract_profile import (  # noqa: E402
+    UnsupportedSourceContractProfile,
+    normalize_file,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    normalize_file(args.input, args.output)
+    print(f"normalize-source-contract-profile: PASS: output={args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, UnsupportedSourceContractProfile) as exc:
+        print(f"normalize-source-contract-profile: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/write-source-proof-binding.py
+++ b/scripts/gen/write-source-proof-binding.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Write a digest binding for a source-contract proof run."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.source_proof_binding import (  # noqa: E402
+    SourceProofBindingError,
+    write_binding,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True, type=Path)
+    parser.add_argument("--producer-executable", required=True, type=Path)
+    parser.add_argument("--typed-corehir", required=True, type=Path)
+    parser.add_argument("--verified-core-machine", required=True, type=Path)
+    parser.add_argument("--verified-core-normalized", required=True, type=Path)
+    parser.add_argument("--solver-input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    write_binding(
+        {
+            "source": args.source,
+            "producer_executable": args.producer_executable,
+            "typed_corehir": args.typed_corehir,
+            "verified_core_machine": args.verified_core_machine,
+            "verified_core_normalized": args.verified_core_normalized,
+            "solver_input": args.solver_input,
+        },
+        args.output,
+    )
+    print(f"write-source-proof-binding: PASS: output={args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, SourceProofBindingError, ValueError) as exc:
+        print(f"write-source-proof-binding: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/proof/normalize_source_contract_profile.py
+++ b/scripts/proof/normalize_source_contract_profile.py
@@ -1,0 +1,72 @@
+"""Normalize comparison-only source contracts to the mathematical SMT profile."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+from proof.verified_core import validate_document
+
+
+class UnsupportedSourceContractProfile(ValueError):
+    """The compiler artifact cannot be soundly normalized to mathematical integers."""
+
+
+_ARITHMETIC_KINDS = {"add", "sub", "mul", "div", "mod", "neg"}
+
+
+def _reject_arithmetic(expression: dict[str, Any], path: str) -> None:
+    kind = expression["kind"]
+    if kind in _ARITHMETIC_KINDS:
+        raise UnsupportedSourceContractProfile(
+            f"{path}.kind: machine arithmetic cannot be normalized: {kind}"
+        )
+    for index, operand in enumerate(expression.get("operands", [])):
+        _reject_arithmetic(operand, f"{path}.operands[{index}]")
+
+
+def normalize_document(value: Any) -> dict[str, Any]:
+    document = validate_document(value)
+    profile = document["target_profile"]
+    if profile["floating_point"] not in {"unsupported", "ieee754"}:
+        raise UnsupportedSourceContractProfile(
+            "$.target_profile.floating_point: unknown source floating-point profile"
+        )
+
+    for function_index, function in enumerate(document["functions"]):
+        for contract_index, contract in enumerate(function["contracts"]):
+            _reject_arithmetic(
+                contract["expression"],
+                f"$.functions[{function_index}].contracts[{contract_index}].expression",
+            )
+
+    normalized = copy.deepcopy(document)
+    normalized["generator"] = (
+        str(document["generator"]) + "+comparison-profile-normalizer-v1"
+    )
+    normalized["target_profile"] = {
+        "integer_model": "mathematical",
+        "overflow": "checked",
+        "floating_point": "unsupported",
+        "pointer_width": profile["pointer_width"],
+    }
+    return validate_document(normalized)
+
+
+def normalize_file(input_path: Path, output_path: Path) -> None:
+    value = json.loads(input_path.read_text(encoding="utf-8"))
+    normalized = normalize_document(value)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(normalized, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+__all__ = [
+    "UnsupportedSourceContractProfile",
+    "normalize_document",
+    "normalize_file",
+]

--- a/scripts/proof/source_proof_binding.py
+++ b/scripts/proof/source_proof_binding.py
@@ -1,0 +1,109 @@
+"""Digest binding for the source-contract proof pipeline."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Mapping
+
+SCHEMA = "arukellt-source-proof-binding"
+VERSION = 1
+REQUIRED_ARTIFACTS = (
+    "source",
+    "producer_executable",
+    "typed_corehir",
+    "verified_core_machine",
+    "verified_core_normalized",
+    "solver_input",
+)
+
+
+class SourceProofBindingError(ValueError):
+    """A source proof binding is missing data or contains stale digests."""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def create_binding(paths: Mapping[str, Path]) -> dict[str, object]:
+    missing = [name for name in REQUIRED_ARTIFACTS if name not in paths]
+    if missing:
+        raise SourceProofBindingError(f"missing binding artifact(s): {missing}")
+    artifacts: list[dict[str, str]] = []
+    for name in REQUIRED_ARTIFACTS:
+        path = paths[name]
+        if not path.is_file():
+            raise SourceProofBindingError(f"{name}: file not found: {path}")
+        artifacts.append(
+            {
+                "name": name,
+                "path": path.as_posix(),
+                "sha256": sha256_file(path),
+            }
+        )
+    return {
+        "schema": SCHEMA,
+        "schema_version": VERSION,
+        "artifacts": artifacts,
+    }
+
+
+def write_binding(paths: Mapping[str, Path], output: Path) -> dict[str, object]:
+    document = create_binding(paths)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return document
+
+
+def validate_binding(value: object, paths: Mapping[str, Path]) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise SourceProofBindingError("binding must be an object")
+    if value.get("schema") != SCHEMA or value.get("schema_version") != VERSION:
+        raise SourceProofBindingError("binding schema identity mismatch")
+    entries = value.get("artifacts")
+    if not isinstance(entries, list):
+        raise SourceProofBindingError("binding artifacts must be an array")
+    by_name: dict[str, dict[str, object]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+            raise SourceProofBindingError("invalid binding artifact entry")
+        name = str(entry["name"])
+        if name in by_name:
+            raise SourceProofBindingError(f"duplicate binding artifact: {name}")
+        by_name[name] = entry
+    if set(by_name) != set(REQUIRED_ARTIFACTS):
+        raise SourceProofBindingError(
+            f"binding artifact set mismatch: {sorted(by_name)}"
+        )
+    for name in REQUIRED_ARTIFACTS:
+        path = paths.get(name)
+        if path is None or not path.is_file():
+            raise SourceProofBindingError(f"{name}: file not found")
+        expected = sha256_file(path)
+        actual = by_name[name].get("sha256")
+        if actual != expected:
+            raise SourceProofBindingError(
+                f"{name}: digest mismatch: expected {expected}, got {actual}"
+            )
+    return value
+
+
+__all__ = [
+    "REQUIRED_ARTIFACTS",
+    "SCHEMA",
+    "VERSION",
+    "SourceProofBindingError",
+    "create_binding",
+    "sha256_file",
+    "validate_binding",
+    "write_binding",
+]

--- a/scripts/proof/typed_corehir.py
+++ b/scripts/proof/typed_corehir.py
@@ -1,4 +1,4 @@
-"""Independent public validator for typed CoreHIR v1 artifacts."""
+"""Independent public validator for TypedCoreHIR v1 artifacts."""
 
 from __future__ import annotations
 
@@ -12,12 +12,89 @@ SCHEMA = "arukellt-typed-corehir"
 VERSION = 1
 
 
+def _validate_explicit_type_metadata(document: dict[str, Any]) -> None:
+    types = document.get("types")
+    if not isinstance(types, list) or not types:
+        raise ValueError("$.types: expected non-empty array")
+    for index, entry in enumerate(types):
+        path = f"$.types[{index}]"
+        if not isinstance(entry, dict):
+            raise ValueError(f"{path}: expected object")
+        kind = entry.get("kind")
+        if kind == "integer":
+            if set(entry) != {
+                "id", "kind", "name", "bits", "signed", "value_type", "representation"
+            }:
+                raise ValueError(
+                    f"{path}: integer type requires explicit bits and signed fields"
+                )
+            bits = entry.get("bits")
+            signed = entry.get("signed")
+            if type(bits) is not int or bits not in {32, 64}:
+                raise ValueError(f"{path}.bits: expected 32 or 64")
+            if signed is not True:
+                raise ValueError(f"{path}.signed: only signed proof integers are supported")
+        elif "bits" in entry or "signed" in entry:
+            raise ValueError(f"{path}: non-integer type must not carry bits or signed")
+
+
+def _compatibility_root_set(document: dict[str, Any]) -> None:
+    """Represent body and contract roots as one validation-only root."""
+
+    for function in document.get("functions", []):
+        contracts = function.get("contracts", [])
+        if not contracts:
+            continue
+        body = function.get("body")
+        if not isinstance(body, dict):
+            continue
+        expressions = body.get("expressions")
+        root = body.get("root_expr_id")
+        if not isinstance(expressions, list) or not isinstance(root, int):
+            continue
+        existing_ids = [
+            expression.get("id")
+            for expression in expressions
+            if isinstance(expression, dict) and isinstance(expression.get("id"), int)
+        ]
+        synthetic_id = max(existing_ids, default=-1) + 1
+        roots = [root]
+        for contract in contracts:
+            if not isinstance(contract, dict):
+                continue
+            expression_id = contract.get("expression_id")
+            if isinstance(expression_id, int) and expression_id not in roots:
+                roots.append(expression_id)
+        expressions.append(
+            {
+                "id": synthetic_id,
+                "kind": "proof-root-set",
+                "kind_id": 20,
+                "type_id": 0,
+                "value_type": "void",
+                "text": "",
+                "int_value": 0,
+                "float_value": 0.0,
+                "span_start": 0,
+                "children": roots,
+            }
+        )
+        body["root_expr_id"] = synthetic_id
+
+
 def validate_document(value: Any) -> dict[str, Any]:
     document = object_value(value, "$")
     validate_header(document, "$", SCHEMA, VERSION)
+    _validate_explicit_type_metadata(document)
+
     compatibility = copy.deepcopy(document)
     compatibility["schema"] = _typed_corehir_impl.SCHEMA
     compatibility["schema_version"] = _typed_corehir_impl.VERSION
+    for entry in compatibility.get("types", []):
+        if isinstance(entry, dict):
+            entry.pop("bits", None)
+            entry.pop("signed", None)
+    _compatibility_root_set(compatibility)
     _typed_corehir_impl.validate_document(compatibility)
     return document
 

--- a/scripts/proof/typed_corehir_convert.py
+++ b/scripts/proof/typed_corehir_convert.py
@@ -1,83 +1,78 @@
-"""Fail-closed TypedCoreHIR v1 to VerifiedCore v1 conversion."""
+"""Fail-closed TypedCoreHIR v1 to VerifiedCore v1 conversion.
+
+Only functions carrying contracts are promoted to VerifiedCore. Uncontracted
+runtime helpers and unrelated type-table entries remain outside the proof
+subject rather than becoming implicit obligations or trusted assumptions.
+"""
 
 from __future__ import annotations
 
 import copy
 from typing import Any
 
-from proof.common import array_value, exact_keys, int_value, object_value, string_value, validate_header
+from proof.common import array_value, exact_keys, int_value, object_value, string_value
+from proof.typed_corehir import validate_document as validate_typed_corehir
 from proof.verified_core import validate_document as validate_verified_core
-
-SOURCE_SCHEMA = "arukellt-typed-corehir"
-SOURCE_VERSION = 1
 
 
 class UnsupportedTypedCoreHir(ValueError):
-    """Raised when a valid-looking TypedCoreHIR artifact is outside the conversion subset."""
+    """Valid TypedCoreHIR that is outside the current proof conversion subset."""
 
 
-def _type_table(document: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[int, dict[str, Any]]]:
-    rendered: list[dict[str, Any]] = []
+def _index_types(document: dict[str, Any]) -> dict[int, dict[str, Any]]:
     by_id: dict[int, dict[str, Any]] = {}
     for index, raw in enumerate(array_value(document["types"], "$.types")):
-        path = f"$.types[{index}]"
-        entry = object_value(raw, path)
-        exact_keys(entry, path, required={"id", "kind", "name", "value_type", "representation"})
-        type_id = int_value(entry["id"], f"{path}.id", minimum=0)
+        entry = object_value(raw, f"$.types[{index}]")
+        type_id = int_value(entry["id"], f"$.types[{index}].id", minimum=0)
         if type_id in by_id:
-            raise UnsupportedTypedCoreHir(f"{path}.id: duplicate type id {type_id}")
-        kind = string_value(entry["kind"], f"{path}.kind")
-        name = string_value(entry["name"], f"{path}.name")
-        representation = object_value(entry["representation"], f"{path}.representation")
-        exact_keys(
-            representation,
-            f"{path}.representation",
-            required={"kind", "wasm", "nullable", "size_bytes", "align_bytes"},
-        )
-        verified_type: dict[str, Any] = {
-            "id": type_id,
-            "kind": kind,
-            "name": name,
-            "representation": {
-                "wasm": copy.deepcopy(representation["wasm"]),
-                "nullable": representation["nullable"],
-                "size_bytes": representation["size_bytes"],
-                "align_bytes": representation["align_bytes"],
-            },
-        }
-        if kind == "integer":
-            if name == "i32":
-                verified_type["bits"] = 32
-                verified_type["signed"] = True
-            elif name == "i64":
-                verified_type["bits"] = 64
-                verified_type["signed"] = True
-            else:
-                raise UnsupportedTypedCoreHir(f"{path}.name: unsupported integer type {name!r}")
-        elif kind not in {"unit", "bool"}:
-            raise UnsupportedTypedCoreHir(f"{path}.kind: unsupported proof type {kind!r}")
-        rendered.append(verified_type)
+            raise UnsupportedTypedCoreHir(f"$.types[{index}].id: duplicate type id {type_id}")
         by_id[type_id] = entry
-    if not rendered:
-        raise UnsupportedTypedCoreHir("$.types: at least one type is required")
-    return rendered, by_id
+    return by_id
 
 
-def _locals(function: dict[str, Any], path: str, known_types: set[int]) -> tuple[list[dict[str, Any]], dict[str, int]]:
+def _verified_type(entry: dict[str, Any], path: str) -> dict[str, Any]:
+    kind = string_value(entry["kind"], f"{path}.kind")
+    name = string_value(entry["name"], f"{path}.name")
+    representation = object_value(entry["representation"], f"{path}.representation")
+    rendered: dict[str, Any] = {
+        "id": int_value(entry["id"], f"{path}.id", minimum=0),
+        "kind": kind,
+        "name": name,
+        "representation": {
+            "wasm": copy.deepcopy(representation["wasm"]),
+            "nullable": representation["nullable"],
+            "size_bytes": representation["size_bytes"],
+            "align_bytes": representation["align_bytes"],
+        },
+    }
+    if kind == "integer":
+        if name == "i32":
+            rendered.update(bits=32, signed=True)
+        elif name == "i64":
+            rendered.update(bits=64, signed=True)
+        else:
+            raise UnsupportedTypedCoreHir(f"{path}.name: unsupported integer type {name!r}")
+    elif kind not in {"unit", "bool"}:
+        raise UnsupportedTypedCoreHir(f"{path}.kind: unsupported reachable proof type {kind!r}")
+    return rendered
+
+
+def _locals(
+    function: dict[str, Any], path: str
+) -> tuple[list[dict[str, Any]], dict[str, int], set[int]]:
     rendered: list[dict[str, Any]] = []
     name_to_id: dict[str, int] = {}
+    used_types: set[int] = set()
     for index, raw in enumerate(array_value(function["locals"], f"{path}.locals")):
         local_path = f"{path}.locals[{index}]"
         local = object_value(raw, local_path)
-        exact_keys(local, local_path, required={"id", "name", "type_id", "storage"})
         local_id = int_value(local["id"], f"{local_path}.id", minimum=0)
         name = string_value(local["name"], f"{local_path}.name")
         type_id = int_value(local["type_id"], f"{local_path}.type_id", minimum=0)
-        if type_id not in known_types:
-            raise UnsupportedTypedCoreHir(f"{local_path}.type_id: unknown type {type_id}")
         if name in name_to_id:
             raise UnsupportedTypedCoreHir(f"{local_path}.name: duplicate local name {name!r}")
         name_to_id[name] = local_id
+        used_types.add(type_id)
         rendered.append(
             {
                 "id": local_id,
@@ -86,46 +81,24 @@ def _locals(function: dict[str, Any], path: str, known_types: set[int]) -> tuple
                 "storage": string_value(local["storage"], f"{local_path}.storage"),
             }
         )
-    return rendered, name_to_id
+    return rendered, name_to_id, used_types
 
 
-def _expression_index(function: dict[str, Any], path: str) -> tuple[int, dict[int, dict[str, Any]]]:
+def _expression_index(
+    function: dict[str, Any], path: str
+) -> tuple[int, dict[int, dict[str, Any]]]:
     body = object_value(function["body"], f"{path}.body")
-    exact_keys(body, f"{path}.body", required={"root_expr_id", "expressions"})
     root = int_value(body["root_expr_id"], f"{path}.body.root_expr_id", minimum=0)
     by_id: dict[int, dict[str, Any]] = {}
     for index, raw in enumerate(array_value(body["expressions"], f"{path}.body.expressions")):
         expr_path = f"{path}.body.expressions[{index}]"
         expr = object_value(raw, expr_path)
-        exact_keys(
-            expr,
-            expr_path,
-            required={
-                "id",
-                "kind",
-                "kind_id",
-                "type_id",
-                "value_type",
-                "text",
-                "int_value",
-                "float_value",
-                "span_start",
-                "children",
-            },
-        )
         expr_id = int_value(expr["id"], f"{expr_path}.id", minimum=0)
         if expr_id in by_id:
             raise UnsupportedTypedCoreHir(f"{expr_path}.id: duplicate expression id {expr_id}")
         by_id[expr_id] = expr
     if root not in by_id:
         raise UnsupportedTypedCoreHir(f"{path}.body.root_expr_id: unknown expression {root}")
-    for expr_id, expr in by_id.items():
-        for child_index, child in enumerate(array_value(expr["children"], f"{path}.body.expressions[{expr_id}].children")):
-            child_id = int_value(child, f"{path}.body.expressions[{expr_id}].children[{child_index}]", minimum=0)
-            if child_id not in by_id:
-                raise UnsupportedTypedCoreHir(
-                    f"{path}.body.expressions[{expr_id}].children[{child_index}]: unknown expression {child_id}"
-                )
     return root, by_id
 
 
@@ -148,68 +121,73 @@ _UNARY_KINDS = {"!": "not", "-": "neg"}
 
 
 def _proof_expression(
-    expr_id: int,
+    source_id: int,
     expressions: dict[int, dict[str, Any]],
     local_ids: dict[str, int],
     result_name: str,
     stack: set[int],
     next_id: list[int],
+    used_types: set[int],
     path: str,
 ) -> dict[str, Any]:
-    if expr_id in stack:
-        raise UnsupportedTypedCoreHir(f"{path}: expression cycle at {expr_id}")
-    stack = set(stack)
-    stack.add(expr_id)
-    expr = expressions[expr_id]
+    if source_id in stack:
+        raise UnsupportedTypedCoreHir(f"{path}: expression cycle at {source_id}")
+    if source_id not in expressions:
+        raise UnsupportedTypedCoreHir(f"{path}: unknown expression {source_id}")
+    stack = {*stack, source_id}
+    expr = expressions[source_id]
     kind = string_value(expr["kind"], f"{path}.kind")
     type_id = int_value(expr["type_id"], f"{path}.type_id", minimum=0)
-    text = expr["text"]
+    used_types.add(type_id)
+    text = str(expr["text"])
     children = [int_value(value, f"{path}.children", minimum=0) for value in expr["children"]]
     verified_id = next_id[0]
     next_id[0] += 1
     common: dict[str, Any] = {"id": verified_id, "type_id": type_id}
 
     if kind in {"ident", "path"}:
-        name = string_value(text, f"{path}.text")
-        if result_name and name == result_name:
+        if result_name and text == result_name:
             return {**common, "kind": "result"}
-        if name not in local_ids:
-            raise UnsupportedTypedCoreHir(f"{path}.text: unknown proof identifier {name!r}")
-        return {**common, "kind": "local", "local_id": local_ids[name]}
+        if text not in local_ids:
+            raise UnsupportedTypedCoreHir(f"{path}.text: unknown proof identifier {text!r}")
+        return {**common, "kind": "local", "local_id": local_ids[text]}
     if kind == "int":
-        return {**common, "kind": "constant", "value": int_value(expr["int_value"], f"{path}.int_value")}
+        return {**common, "kind": "constant", "value": int(expr["int_value"])}
     if kind == "bool":
-        normalized = str(text).lower()
+        normalized = text.lower()
         if normalized not in {"true", "false"}:
             raise UnsupportedTypedCoreHir(f"{path}.text: invalid boolean literal {text!r}")
         return {**common, "kind": "constant", "value": normalized == "true"}
     if kind == "binary":
-        operator = string_value(text, f"{path}.text")
-        verified_kind = _BINARY_KINDS.get(operator)
-        if verified_kind is None:
-            raise UnsupportedTypedCoreHir(f"{path}.text: unsupported binary operator {operator!r}")
-        if len(children) != 2:
-            raise UnsupportedTypedCoreHir(f"{path}.children: binary expression requires two children")
+        verified_kind = _BINARY_KINDS.get(text)
+        if verified_kind is None or len(children) != 2:
+            raise UnsupportedTypedCoreHir(f"{path}: unsupported binary expression {text!r}")
         return {
             **common,
             "kind": verified_kind,
             "operands": [
-                _proof_expression(children[0], expressions, local_ids, result_name, stack, next_id, f"{path}.children[0]"),
-                _proof_expression(children[1], expressions, local_ids, result_name, stack, next_id, f"{path}.children[1]"),
+                _proof_expression(
+                    children[0], expressions, local_ids, result_name, stack,
+                    next_id, used_types, f"{path}.children[0]"
+                ),
+                _proof_expression(
+                    children[1], expressions, local_ids, result_name, stack,
+                    next_id, used_types, f"{path}.children[1]"
+                ),
             ],
         }
     if kind == "unary":
-        operator = string_value(text, f"{path}.text")
-        verified_kind = _UNARY_KINDS.get(operator)
-        if verified_kind is None:
-            raise UnsupportedTypedCoreHir(f"{path}.text: unsupported unary operator {operator!r}")
-        if len(children) != 1:
-            raise UnsupportedTypedCoreHir(f"{path}.children: unary expression requires one child")
+        verified_kind = _UNARY_KINDS.get(text)
+        if verified_kind is None or len(children) != 1:
+            raise UnsupportedTypedCoreHir(f"{path}: unsupported unary expression {text!r}")
         return {
             **common,
             "kind": verified_kind,
             "operands": [
-                _proof_expression(children[0], expressions, local_ids, result_name, stack, next_id, f"{path}.children[0]")
+                _proof_expression(
+                    children[0], expressions, local_ids, result_name, stack,
+                    next_id, used_types, f"{path}.children[0]"
+                )
             ],
         }
     raise UnsupportedTypedCoreHir(f"{path}.kind: unsupported proof expression kind {kind!r}")
@@ -220,10 +198,10 @@ def _return_value(
     expressions: dict[int, dict[str, Any]],
     contract_ids: set[int],
     local_ids: dict[str, int],
+    used_types: set[int],
     path: str,
 ) -> dict[str, Any]:
     root = expressions[root_id]
-    candidates: list[int]
     if root["kind"] == "block":
         candidates = [int(child) for child in root["children"] if int(child) not in contract_ids]
     else:
@@ -234,84 +212,79 @@ def _return_value(
         )
     expr = expressions[candidates[0]]
     type_id = int_value(expr["type_id"], f"{path}.body.return.type_id", minimum=0)
-    if expr["kind"] in {"ident", "path"}:
-        name = string_value(expr["text"], f"{path}.body.return.text")
+    used_types.add(type_id)
+    kind = str(expr["kind"])
+    if kind in {"ident", "path"}:
+        name = str(expr["text"])
         if name not in local_ids:
             raise UnsupportedTypedCoreHir(f"{path}.body.return.text: unknown local {name!r}")
         return {"kind": "local", "type_id": type_id, "local_id": local_ids[name]}
-    if expr["kind"] == "int":
+    if kind == "int":
         return {"kind": "constant", "type_id": type_id, "value": int(expr["int_value"])}
-    if expr["kind"] == "bool":
+    if kind == "bool":
         normalized = str(expr["text"]).lower()
         if normalized not in {"true", "false"}:
             raise UnsupportedTypedCoreHir(f"{path}.body.return.text: invalid boolean literal")
         return {"kind": "constant", "type_id": type_id, "value": normalized == "true"}
     raise UnsupportedTypedCoreHir(
-        f"{path}.body.return.kind: unsupported executable return expression {expr['kind']!r}"
+        f"{path}.body.return.kind: unsupported executable return expression {kind!r}"
     )
 
 
 def convert_document(value: Any) -> dict[str, Any]:
-    source = object_value(value, "$")
-    validate_header(source, "$", SOURCE_SCHEMA, SOURCE_VERSION)
-    exact_keys(
-        source,
-        "$",
-        required={"schema", "schema_version", "generator", "module", "target_profile", "types", "functions"},
-    )
-    verified_types, source_types = _type_table(source)
-    known_types = set(source_types)
+    source = validate_typed_corehir(value)
+    source_types = _index_types(source)
+    used_types: set[int] = set()
     verified_functions: list[dict[str, Any]] = []
 
     for function_index, raw in enumerate(array_value(source["functions"], "$.functions")):
         path = f"$.functions[{function_index}]"
         function = object_value(raw, path)
-        exact_keys(
-            function,
-            path,
-            required={"id", "name", "signature", "abi", "locals", "contracts", "body"},
-        )
-        rendered_locals, local_ids = _locals(function, path, known_types)
+        source_contracts = array_value(function["contracts"], f"{path}.contracts")
+        if not source_contracts:
+            continue
+
+        rendered_locals, local_ids, local_types = _locals(function, path)
+        used_types.update(local_types)
+        signature = object_value(function["signature"], f"{path}.signature")
+        used_types.add(int(signature["return_type_id"]))
+        for parameter in signature["parameters"]:
+            used_types.add(int(parameter["type_id"]))
+
         root_id, expressions = _expression_index(function, path)
         contracts: list[dict[str, Any]] = []
         contract_ids: set[int] = set()
         next_proof_id = [0]
-        for contract_index, raw_contract in enumerate(array_value(function["contracts"], f"{path}.contracts")):
+        for contract_index, raw_contract in enumerate(source_contracts):
             contract_path = f"{path}.contracts[{contract_index}]"
             contract = object_value(raw_contract, contract_path)
-            exact_keys(contract, contract_path, required={"kind", "expression_id"}, optional={"result_name"})
             kind = string_value(contract["kind"], f"{contract_path}.kind")
             if kind not in {"requires", "ensures"}:
                 raise UnsupportedTypedCoreHir(f"{contract_path}.kind: unsupported contract {kind!r}")
-            expression_id = int_value(contract["expression_id"], f"{contract_path}.expression_id", minimum=0)
-            if expression_id not in expressions:
-                raise UnsupportedTypedCoreHir(f"{contract_path}.expression_id: unknown expression {expression_id}")
+            expression_id = int_value(
+                contract["expression_id"], f"{contract_path}.expression_id", minimum=0
+            )
             contract_ids.add(expression_id)
             result_name = str(contract.get("result_name", "result" if kind == "ensures" else ""))
             rendered: dict[str, Any] = {
                 "kind": kind,
                 "expression": _proof_expression(
-                    expression_id,
-                    expressions,
-                    local_ids,
-                    result_name,
-                    set(),
-                    next_proof_id,
-                    f"{contract_path}.expression",
+                    expression_id, expressions, local_ids, result_name, set(),
+                    next_proof_id, used_types, f"{contract_path}.expression"
                 ),
             }
             if result_name:
                 rendered["result_name"] = result_name
             contracts.append(rendered)
-        if not contracts:
-            raise UnsupportedTypedCoreHir(f"{path}.contracts: at least one contract is required")
 
-        return_value = _return_value(root_id, expressions, contract_ids, local_ids, path)
+        return_value = _return_value(
+            root_id, expressions, contract_ids, local_ids, used_types, path
+        )
         verified_functions.append(
             {
                 "id": function["id"],
                 "name": function["name"],
-                "signature": copy.deepcopy(function["signature"]),
+                "signature": copy.deepcopy(signature),
                 "abi": copy.deepcopy(function["abi"]),
                 "locals": rendered_locals,
                 "contracts": contracts,
@@ -329,6 +302,16 @@ def convert_document(value: Any) -> dict[str, Any]:
             }
         )
 
+    if not verified_functions:
+        raise UnsupportedTypedCoreHir("$.functions: no contracted functions")
+    missing = sorted(type_id for type_id in used_types if type_id not in source_types)
+    if missing:
+        raise UnsupportedTypedCoreHir(f"$.types: missing reachable type ids {missing}")
+    verified_types = [
+        _verified_type(source_types[type_id], f"$.types[id={type_id}]")
+        for type_id in sorted(used_types)
+    ]
+
     result = {
         "schema": "arukellt-verified-core",
         "schema_version": 1,
@@ -341,4 +324,4 @@ def convert_document(value: Any) -> dict[str, Any]:
     return validate_verified_core(result)
 
 
-__all__ = ["SOURCE_SCHEMA", "SOURCE_VERSION", "UnsupportedTypedCoreHir", "convert_document"]
+__all__ = ["UnsupportedTypedCoreHir", "convert_document"]

--- a/scripts/proof/typed_corehir_typed_convert.py
+++ b/scripts/proof/typed_corehir_typed_convert.py
@@ -1,9 +1,8 @@
 """Explicitly typed TypedCoreHIR v1 to VerifiedCore v1 conversion boundary.
 
-This v2 boundary requires logical integer metadata in the source artifact and
-normalizes the legacy converter input from that metadata. Source type names are
-preserved for identity and are never used to derive bits, signedness, ABI, or
-representation.
+The internal converter is permitted to select the contracted proof subject, but
+all logical meaning of reachable integer types is re-established from explicit
+``bits`` and ``signed`` metadata. Source type names are identity-only.
 """
 
 from __future__ import annotations
@@ -12,18 +11,18 @@ import copy
 from typing import Any
 
 from proof.typed_corehir_convert import (
-    SOURCE_SCHEMA,
-    SOURCE_VERSION,
     UnsupportedTypedCoreHir,
     convert_document as convert_legacy_document,
 )
 from proof.verified_core_typed import validate_typed_document
 
+SOURCE_SCHEMA = "arukellt-typed-corehir"
+SOURCE_VERSION = 1
 CONVERTER = "arukellt-typed-corehir-converter-v2"
 
 
 class ExplicitTypedCoreHirError(UnsupportedTypedCoreHir):
-    """TypedCoreHIR lacks explicit logical type information or is inconsistent."""
+    """Reachable proof types lack explicit or consistent logical metadata."""
 
 
 def _require(condition: bool, message: str) -> None:
@@ -64,17 +63,18 @@ def _validate_representation(
     )
     representation = entry.get("representation")
     _require(isinstance(representation, dict), f"{path}.representation: expected object")
-    wasm = representation.get("wasm")
-    _require(wasm == expected_wasm, f"{path}.representation.wasm: explicit type mismatch")
+    _require(
+        representation.get("wasm") == expected_wasm,
+        f"{path}.representation.wasm: explicit type mismatch",
+    )
     _require(
         representation.get("nullable") is False,
         f"{path}.representation.nullable: scalar type must be non-nullable",
     )
-    _require(
-        _require_int(representation.get("size_bytes"), f"{path}.representation.size_bytes")
-        == expected_size,
-        f"{path}.representation.size_bytes: explicit type mismatch",
+    size = _require_int(
+        representation.get("size_bytes"), f"{path}.representation.size_bytes"
     )
+    _require(size == expected_size, f"{path}.representation.size_bytes: explicit type mismatch")
     align = _require_int(
         representation.get("align_bytes"),
         f"{path}.representation.align_bytes",
@@ -86,7 +86,9 @@ def _validate_representation(
     )
 
 
-def _normalize_types(source: dict[str, Any]) -> tuple[dict[str, Any], dict[int, dict[str, Any]]]:
+def _normalize_source(
+    source: dict[str, Any],
+) -> tuple[dict[str, Any], dict[int, dict[str, Any]]]:
     raw_types = source.get("types")
     _require(isinstance(raw_types, list) and raw_types, "$.types: expected non-empty array")
     normalized = copy.deepcopy(source)
@@ -101,19 +103,9 @@ def _normalize_types(source: dict[str, Any]) -> tuple[dict[str, Any], dict[int, 
         kind = _require_string(raw.get("kind"), f"{path}.kind")
         _require_string(raw.get("name"), f"{path}.name")
         explicit = copy.deepcopy(raw)
-        legacy = {
-            key: copy.deepcopy(raw[key])
-            for key in ("id", "kind", "name", "value_type", "representation")
-            if key in raw
-        }
+        legacy = copy.deepcopy(raw)
 
         if kind == "integer":
-            _require(
-                set(raw) == {
-                    "id", "kind", "name", "bits", "signed", "value_type", "representation"
-                },
-                f"{path}: integer type requires explicit bits and signed fields",
-            )
             bits = _require_int(raw.get("bits"), f"{path}.bits", minimum=1)
             signed = _require_bool(raw.get("signed"), f"{path}.signed")
             _require(signed and bits in {32, 64}, f"{path}: only explicit signed i32/i64 are supported")
@@ -125,37 +117,9 @@ def _normalize_types(source: dict[str, Any]) -> tuple[dict[str, Any], dict[int, 
                 expected_wasm=[expected],
                 expected_size=bits // 8,
             )
-            # The legacy implementation receives a canonical internal name
-            # derived from explicit metadata, never the source identity name.
+            # Canonical internal normalization derives from explicit metadata.
+            # The source identity name is restored after conversion.
             legacy["name"] = expected
-        elif kind == "bool":
-            _require(
-                set(raw) == {"id", "kind", "name", "value_type", "representation"},
-                f"{path}: bool type contains unsupported inferred metadata",
-            )
-            _validate_representation(
-                raw,
-                path=path,
-                expected_value_type="i32",
-                expected_wasm=["i32"],
-                expected_size=4,
-            )
-        elif kind == "unit":
-            _require(
-                set(raw) == {"id", "kind", "name", "value_type", "representation"},
-                f"{path}: unit type contains unsupported inferred metadata",
-            )
-            _validate_representation(
-                raw,
-                path=path,
-                expected_value_type="void",
-                expected_wasm=[],
-                expected_size=0,
-            )
-        else:
-            raise ExplicitTypedCoreHirError(
-                f"{path}.kind: unsupported explicit proof type {kind!r}"
-            )
 
         explicit_by_id[type_id] = explicit
         normalized_types.append(legacy)
@@ -164,35 +128,77 @@ def _normalize_types(source: dict[str, Any]) -> tuple[dict[str, Any], dict[int, 
     return normalized, explicit_by_id
 
 
+def _admit_reachable_type(
+    rendered: dict[str, Any], explicit: dict[str, Any], *, path: str
+) -> None:
+    kind = explicit.get("kind")
+    _require(rendered.get("kind") == kind, f"{path}.kind: converter changed type kind")
+    if kind == "integer":
+        bits = _require_int(explicit.get("bits"), f"{path}.bits", minimum=1)
+        signed = _require_bool(explicit.get("signed"), f"{path}.signed")
+        _require(signed and bits in {32, 64}, f"{path}: unsupported proof integer")
+        expected = f"i{bits}"
+        _validate_representation(
+            explicit,
+            path=path,
+            expected_value_type=expected,
+            expected_wasm=[expected],
+            expected_size=bits // 8,
+        )
+        rendered["bits"] = bits
+        rendered["signed"] = signed
+    elif kind == "bool":
+        _validate_representation(
+            explicit,
+            path=path,
+            expected_value_type="i32",
+            expected_wasm=["i32"],
+            expected_size=4,
+        )
+    elif kind == "unit":
+        _validate_representation(
+            explicit,
+            path=path,
+            expected_value_type="void",
+            expected_wasm=[],
+            expected_size=0,
+        )
+    else:
+        raise ExplicitTypedCoreHirError(
+            f"{path}.kind: unsupported reachable proof type {kind!r}"
+        )
+
+    rendered["name"] = explicit["name"]
+    representation = explicit["representation"]
+    _require(
+        rendered["representation"] == {
+            "wasm": representation["wasm"],
+            "nullable": representation["nullable"],
+            "size_bytes": representation["size_bytes"],
+            "align_bytes": representation["align_bytes"],
+        },
+        f"{path}.representation: converter changed explicit representation",
+    )
+
+
 def convert_typed_document(value: Any) -> dict[str, Any]:
     _require(isinstance(value, dict), "$: expected object")
     source = copy.deepcopy(value)
     _require(source.get("schema") == SOURCE_SCHEMA, f"$.schema: expected {SOURCE_SCHEMA!r}")
     _require(source.get("schema_version") == SOURCE_VERSION, f"$.schema_version: expected {SOURCE_VERSION}")
 
-    normalized, explicit_types = _normalize_types(source)
+    normalized, explicit_types = _normalize_source(source)
     try:
         converted = convert_legacy_document(normalized)
     except UnsupportedTypedCoreHir as exc:
         raise ExplicitTypedCoreHirError(str(exc)) from exc
-    converted_by_id = {int(entry["id"]): entry for entry in converted["types"]}
-    _require(set(converted_by_id) == set(explicit_types), "$.types: converted type set changed")
 
-    for type_id, explicit in explicit_types.items():
-        rendered = converted_by_id[type_id]
-        rendered["name"] = explicit["name"]
-        if explicit["kind"] == "integer":
-            rendered["bits"] = explicit["bits"]
-            rendered["signed"] = explicit["signed"]
-        _require(
-            rendered["representation"] == {
-                "wasm": explicit["representation"]["wasm"],
-                "nullable": explicit["representation"]["nullable"],
-                "size_bytes": explicit["representation"]["size_bytes"],
-                "align_bytes": explicit["representation"]["align_bytes"],
-            },
-            f"$.types[{type_id}].representation: converter changed explicit representation",
-        )
+    converted_by_id = {int(entry["id"]): entry for entry in converted["types"]}
+    unknown = sorted(set(converted_by_id) - set(explicit_types))
+    _require(not unknown, f"$.types: converter introduced unknown type ids {unknown}")
+    for type_id, rendered in converted_by_id.items():
+        explicit = explicit_types[type_id]
+        _admit_reachable_type(rendered, explicit, path=f"$.types[id={type_id}]")
 
     converted["generator"] = CONVERTER
     return validate_typed_document(converted)
@@ -201,5 +207,7 @@ def convert_typed_document(value: Any) -> dict[str, Any]:
 __all__ = [
     "CONVERTER",
     "ExplicitTypedCoreHirError",
+    "SOURCE_SCHEMA",
+    "SOURCE_VERSION",
     "convert_typed_document",
 ]

--- a/scripts/tests/test_source_contract_profile.py
+++ b/scripts/tests/test_source_contract_profile.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.normalize_source_contract_profile import (  # noqa: E402
+    UnsupportedSourceContractProfile,
+    normalize_document,
+)
+from proof.typed_corehir_contract_convert import convert_document  # noqa: E402
+
+
+class SourceContractProfileTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        typed = json.loads((ROOT / "tests" / "proof" / "typed-corehir.json").read_text())
+        cls.verified = convert_document(typed)
+
+    def test_comparison_only_contract_normalizes(self) -> None:
+        document = copy.deepcopy(self.verified)
+        document["target_profile"] = {
+            "integer_model": "machine",
+            "overflow": "compiler-current",
+            "floating_point": "ieee754",
+            "pointer_width": 32,
+        }
+        normalized = normalize_document(document)
+        self.assertEqual(normalized["target_profile"], {
+            "integer_model": "mathematical",
+            "overflow": "checked",
+            "floating_point": "unsupported",
+            "pointer_width": 32,
+        })
+        self.assertIn("comparison-profile-normalizer-v1", normalized["generator"])
+
+    def test_machine_arithmetic_contract_fails_closed(self) -> None:
+        document = copy.deepcopy(self.verified)
+        expression = document["functions"][0]["contracts"][0]["expression"]
+        expression["kind"] = "add"
+        with self.assertRaisesRegex(
+            UnsupportedSourceContractProfile,
+            "machine arithmetic cannot be normalized",
+        ):
+            normalize_document(document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_source_proof_binding.py
+++ b/scripts/tests/test_source_proof_binding.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.source_proof_binding import (  # noqa: E402
+    REQUIRED_ARTIFACTS,
+    SourceProofBindingError,
+    validate_binding,
+    write_binding,
+)
+
+
+class SourceProofBindingTests(unittest.TestCase):
+    def test_binding_detects_stale_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            paths: dict[str, Path] = {}
+            for index, name in enumerate(REQUIRED_ARTIFACTS):
+                path = root / f"{name}.bin"
+                path.write_bytes(f"artifact-{index}".encode())
+                paths[name] = path
+            output = root / "binding.json"
+            written = write_binding(paths, output)
+            loaded = json.loads(output.read_text())
+            self.assertEqual(written, loaded)
+            validate_binding(loaded, paths)
+
+            paths["typed_corehir"].write_bytes(b"changed")
+            with self.assertRaisesRegex(SourceProofBindingError, "digest mismatch"):
+                validate_binding(loaded, paths)
+
+    def test_binding_requires_complete_artifact_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            paths = {
+                name: root / f"{name}.bin"
+                for name in REQUIRED_ARTIFACTS[:-1]
+            }
+            for path in paths.values():
+                path.write_bytes(b"x")
+            with self.assertRaisesRegex(SourceProofBindingError, "missing binding artifact"):
+                write_binding(paths, root / "binding.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_typed_corehir_artifacts.py
+++ b/scripts/tests/test_typed_corehir_artifacts.py
@@ -26,6 +26,7 @@ class TypedCoreHirArtifactTests(unittest.TestCase):
         checked = validate_document(copy.deepcopy(self.document))
         self.assertEqual(checked["schema"], "arukellt-typed-corehir")
         self.assertEqual(checked["functions"][0]["body"]["root_expr_id"], 0)
+        self.assertEqual(checked["functions"][0]["contracts"][0]["expression_id"], 2)
 
     def test_rejects_verified_core_identity(self) -> None:
         document = copy.deepcopy(self.document)
@@ -45,9 +46,22 @@ class TypedCoreHirArtifactTests(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "unknown expression id"):
             validate_document(document)
 
-    def test_rejects_unreachable_expression(self) -> None:
+    def test_rejects_unreachable_non_contract_expression(self) -> None:
         document = copy.deepcopy(self.document)
-        document["functions"][0]["body"]["expressions"][0]["children"] = [1]
+        document["functions"][0]["body"]["expressions"].append(
+            {
+                "id": 3,
+                "kind": "ident",
+                "kind_id": 5,
+                "type_id": 1,
+                "value_type": "i32",
+                "text": "orphan",
+                "int_value": 0,
+                "float_value": 0.0,
+                "span_start": 3,
+                "children": [],
+            }
+        )
         with self.assertRaisesRegex(ValidationError, "unreachable expression"):
             validate_document(document)
 

--- a/src/compiler/corehir/body_roots.ark
+++ b/src/compiler/corehir/body_roots.ark
@@ -1,7 +1,40 @@
 use corehir::body
+use corehir::body_table
 use corehir::decl_children
 use corehir::decl_member_collections
 use corehir::decl_node
+use corehir::frontend_ast_node
+use corehir::frontend_kind_map
+
+fn lower_fn_contracts(table: CoreHirBodyTable, decl: AstNode) -> i32 {
+    let start = body_table::corehir_body_table_begin_fn_contracts(table)
+    let annotation_count = frontend_ast_node::corehir_node_type_ann_count(decl)
+    let mut annotation_index = 0
+    while annotation_index < annotation_count {
+        let annotation = frontend_ast_node::corehir_node_type_ann_at(decl, annotation_index)
+        if frontend_ast_node::corehir_node_kind(annotation) == frontend_kind_map::nk_proof_contract() {
+            let child_count = frontend_ast_node::corehir_node_child_count(annotation)
+            if child_count == 1 {
+                let expression = frontend_ast_node::corehir_node_child_at(annotation, 0)
+                let root = corehir_build_expr(table, expression)
+                let kind = frontend_ast_node::corehir_node_text(annotation)
+                let result_name = if eq(clone(kind), "ensures") {
+                    "result"
+                } else {
+                    ""
+                }
+                body_table::corehir_body_table_push_fn_contract(
+                    table,
+                    root,
+                    kind,
+                    result_name
+                )
+            }
+        }
+        annotation_index = annotation_index + 1
+    }
+    start
+}
 
 fn build_body_table(decls: Vec<AstNode>) -> CoreHirBodyTable {
     let table = body::CoreHirBodyTable_new()
@@ -10,12 +43,14 @@ fn build_body_table(decls: Vec<AstNode>) -> CoreHirBodyTable {
     while i < decl_count {
         let decl = get_unchecked(decls, i)
         if decl_node::decl_is_fn(decl) {
+            let contract_start = lower_fn_contracts(table, decl)
             let body_idx = decl_children::decl_body_index(decl)
             let mut root = 0 - 1
             if body_idx >= 0 {
                 root = corehir_build_expr(table, decl_children::decl_child_at(decl, body_idx))
             }
             corehir_push_fn_body_root(table, root)
+            body_table::corehir_body_table_end_fn_contracts(table, contract_start)
         }
         if decl_node::decl_is_impl(decl) {
             let method_count = decl_member_collections::decl_method_count(decl)

--- a/src/compiler/corehir/body_table.ark
+++ b/src/compiler/corehir/body_table.ark
@@ -2,10 +2,24 @@ struct CoreHirBodyTable {
     exprs: Vec<CoreHirExpr>,
     fn_body_roots: Vec<i32>,
     method_body_roots: Vec<i32>,
+    fn_contract_starts: Vec<i32>,
+    fn_contract_counts: Vec<i32>,
+    contract_roots: Vec<i32>,
+    contract_kinds: Vec<String>,
+    contract_result_names: Vec<String>,
 }
 
 fn CoreHirBodyTable_new() -> CoreHirBodyTable {
-    CoreHirBodyTable { exprs: Vec::new<CoreHirExpr>(), fn_body_roots: Vec::new<i32>(), method_body_roots: Vec::new<i32>() }
+    CoreHirBodyTable {
+        exprs: Vec::new<CoreHirExpr>(),
+        fn_body_roots: Vec::new<i32>(),
+        method_body_roots: Vec::new<i32>(),
+        fn_contract_starts: Vec::new<i32>(),
+        fn_contract_counts: Vec::new<i32>(),
+        contract_roots: Vec::new<i32>(),
+        contract_kinds: Vec::new<String>(),
+        contract_result_names: Vec::new<String>(),
+    }
 }
 
 fn corehir_body_table_push_expr(table: CoreHirBodyTable, expr: CoreHirExpr) -> i32 {
@@ -40,6 +54,84 @@ fn corehir_body_table_method_body_root_count(table: CoreHirBodyTable) -> i32 {
 
 fn corehir_body_table_method_body_root_at(table: CoreHirBodyTable, index: i32) -> i32 {
     get_unchecked(table.method_body_roots, index)
+}
+
+fn corehir_body_table_begin_fn_contracts(table: CoreHirBodyTable) -> i32 {
+    len(table.contract_roots)
+}
+
+fn corehir_body_table_push_fn_contract(
+    table: CoreHirBodyTable,
+    root: i32,
+    kind: String,
+    result_name: String
+) {
+    push(table.contract_roots, root)
+    push(table.contract_kinds, kind)
+    push(table.contract_result_names, result_name)
+}
+
+fn corehir_body_table_end_fn_contracts(table: CoreHirBodyTable, start: i32) {
+    push(table.fn_contract_starts, start)
+    push(table.fn_contract_counts, len(table.contract_roots) - start)
+}
+
+fn corehir_body_table_fn_contract_count(table: CoreHirBodyTable, body_index: i32) -> i32 {
+    if body_index < 0 || body_index >= len(table.fn_contract_counts) {
+        return 0
+    }
+    get_unchecked(table.fn_contract_counts, body_index)
+}
+
+fn corehir_body_table_fn_contract_flat_index(
+    table: CoreHirBodyTable,
+    body_index: i32,
+    contract_index: i32
+) -> i32 {
+    if body_index < 0 || body_index >= len(table.fn_contract_starts) {
+        return 0 - 1
+    }
+    let count = corehir_body_table_fn_contract_count(table, body_index)
+    if contract_index < 0 || contract_index >= count {
+        return 0 - 1
+    }
+    get_unchecked(table.fn_contract_starts, body_index) + contract_index
+}
+
+fn corehir_body_table_fn_contract_root_at(
+    table: CoreHirBodyTable,
+    body_index: i32,
+    contract_index: i32
+) -> i32 {
+    let flat_index = corehir_body_table_fn_contract_flat_index(table, body_index, contract_index)
+    if flat_index < 0 {
+        return 0 - 1
+    }
+    get_unchecked(table.contract_roots, flat_index)
+}
+
+fn corehir_body_table_fn_contract_kind_at(
+    table: CoreHirBodyTable,
+    body_index: i32,
+    contract_index: i32
+) -> String {
+    let flat_index = corehir_body_table_fn_contract_flat_index(table, body_index, contract_index)
+    if flat_index < 0 {
+        return String_new()
+    }
+    clone(get_unchecked(table.contract_kinds, flat_index))
+}
+
+fn corehir_body_table_fn_contract_result_name_at(
+    table: CoreHirBodyTable,
+    body_index: i32,
+    contract_index: i32
+) -> String {
+    let flat_index = corehir_body_table_fn_contract_flat_index(table, body_index, contract_index)
+    if flat_index < 0 {
+        return String_new()
+    }
+    clone(get_unchecked(table.contract_result_names, flat_index))
 }
 
 fn corehir_body_table_exprs(table: CoreHirBodyTable) -> Vec<CoreHirExpr> {

--- a/src/compiler/corehir/expr_builder_ops.ark
+++ b/src/compiler/corehir/expr_builder_ops.ark
@@ -20,7 +20,24 @@ fn corehir_expr_assign(target_name: String, value_expr: CoreHirExpr, span_start:
     )
 }
 
+fn corehir_binary_result_is_bool(op: i32) -> bool {
+    // Parser operator IDs: comparisons 6..11, logical &&/|| 12..13.
+    op >= 6 && op <= 13
+}
+
 fn corehir_expr_binary(op: i32, left_expr: CoreHirExpr, right_expr: CoreHirExpr, span_start: i32, children: Vec<i32>) -> CoreHirExpr {
+    if corehir_binary_result_is_bool(op) {
+        return expr_factory::CoreHirExpr_new(
+            commands::COREHIR_EXPR_BINARY(),
+            String_new(),
+            op,
+            0.0,
+            value_types::VT_I32(),
+            "bool",
+            span_start,
+            children
+        )
+    }
     let mut vt = value_types::VT_I32()
     if expr_access_types::expr_val_type(left_expr) == value_types::VT_F64() || expr_access_types::expr_val_type(right_expr) == value_types::VT_F64() {
         vt = value_types::VT_F64()
@@ -33,6 +50,18 @@ fn corehir_expr_binary(op: i32, left_expr: CoreHirExpr, right_expr: CoreHirExpr,
 }
 
 fn corehir_expr_unary(op: i32, operand_expr: CoreHirExpr, span_start: i32, children: Vec<i32>) -> CoreHirExpr {
+    if op == 2 {
+        return expr_factory::CoreHirExpr_new(
+            commands::COREHIR_EXPR_UNARY(),
+            String_new(),
+            op,
+            0.0,
+            value_types::VT_I32(),
+            "bool",
+            span_start,
+            children
+        )
+    }
     expr_factory::CoreHirExpr_new(
         commands::COREHIR_EXPR_UNARY(),
         String_new(),

--- a/src/compiler/corehir/frontend_kind_map.ark
+++ b/src/compiler/corehir/frontend_kind_map.ark
@@ -51,3 +51,4 @@ fn nk_type_named() -> i32 { kinds::NK_TYPE_NAMED() }
 fn nk_type_generic() -> i32 { kinds::NK_TYPE_GENERIC() }
 fn nk_type_tuple() -> i32 { kinds::NK_TYPE_TUPLE() }
 fn nk_type_fn() -> i32 { kinds::NK_TYPE_FN() }
+fn nk_proof_contract() -> i32 { kinds::NK_PROOF_CONTRACT() }

--- a/src/compiler/driver/typed_corehir_contract_render.ark
+++ b/src/compiler/driver/typed_corehir_contract_render.ark
@@ -1,0 +1,180 @@
+use corehir::body_table
+use corehir::expr_raw
+use corehir::fn_info
+use corehir::raw_bodies
+use corehir::raw_decls
+use corehir::value_types
+use driver::verified_core_render_primitives
+use driver::verified_core_render_safe
+
+fn tccr_collect_reachable(
+    program: CoreHirRawProgram,
+    function_index: i32,
+    root: i32
+) -> Vec<i32> {
+    let table = raw_bodies::program_body_table(program)
+    let exprs = body_table::corehir_body_table_exprs(table)
+    let reachable = Vec::new<i32>()
+    let stack = Vec::new<i32>()
+    push(stack, root)
+
+    let fn_infos = raw_decls::program_fn_infos(program)
+    let body_index = fn_info::fn_info_body_index_at(fn_infos, function_index, 0 - 1)
+    let contract_count = body_table::corehir_body_table_fn_contract_count(table, body_index)
+    let mut contract_index = 0
+    while contract_index < contract_count {
+        push(
+            stack,
+            body_table::corehir_body_table_fn_contract_root_at(
+                table,
+                body_index,
+                contract_index
+            )
+        )
+        contract_index = contract_index + 1
+    }
+
+    while len(stack) > 0 {
+        let id = pop(stack).unwrap()
+        let mut already_seen = false
+        let mut seen_index = 0
+        while seen_index < len(reachable) {
+            if get_unchecked(reachable, seen_index) == id {
+                already_seen = true
+                seen_index = len(reachable)
+            } else {
+                seen_index = seen_index + 1
+            }
+        }
+        if !already_seen {
+            push(reachable, id)
+            if id >= 0 && id < len(exprs) {
+                let expression = get_unchecked(exprs, id)
+                let child_count = expr_raw::corehir_expr_child_count(expression)
+                let mut child_index = 0
+                while child_index < child_count {
+                    push(stack, expr_raw::corehir_expr_child(expression, child_index))
+                    child_index = child_index + 1
+                }
+            }
+        }
+    }
+    reachable
+}
+
+fn tccr_render_contracts(program: CoreHirRawProgram, function_index: i32) -> String {
+    let fn_infos = raw_decls::program_fn_infos(program)
+    let body_index = fn_info::fn_info_body_index_at(fn_infos, function_index, 0 - 1)
+    let table = raw_bodies::program_body_table(program)
+    let contract_count = body_table::corehir_body_table_fn_contract_count(table, body_index)
+    let mut out = ""
+    let mut contract_index = 0
+    while contract_index < contract_count {
+        if contract_index > 0 {
+            out = concat(out, ",")
+        }
+        let kind_name = body_table::corehir_body_table_fn_contract_kind_at(
+            table,
+            body_index,
+            contract_index
+        )
+        let expression_id = body_table::corehir_body_table_fn_contract_root_at(
+            table,
+            body_index,
+            contract_index
+        )
+        let result_name = body_table::corehir_body_table_fn_contract_result_name_at(
+            table,
+            body_index,
+            contract_index
+        )
+        out = concat(
+            out,
+            concat(
+                "{\"kind\":",
+                verified_core_render_primitives::vc_quote(kind_name)
+            )
+        )
+        out = concat(out, concat(",\"expression_id\":", to_string(expression_id)))
+        if len(clone(result_name)) > 0 {
+            out = concat(
+                out,
+                concat(
+                    ",\"result_name\":",
+                    verified_core_render_primitives::vc_quote(result_name)
+                )
+            )
+        }
+        out = concat(out, "}")
+        contract_index = contract_index + 1
+    }
+    out
+}
+
+fn render_function(program: CoreHirRawProgram, function_index: i32) -> String {
+    if !verified_core_render_safe::vcs_typed_function_exists(program, function_index) {
+        return ""
+    }
+    let root = verified_core_render_safe::vcs_body_root(program, function_index)
+    if !verified_core_render_safe::vcs_body_root_is_valid(program, root) {
+        return ""
+    }
+    let reachable = tccr_collect_reachable(program, function_index, root)
+    if !verified_core_render_safe::vcs_reachable_is_typed(program, reachable) {
+        return ""
+    }
+    let return_vt = verified_core_render_safe::vcs_return_value_type(program, function_index)
+    let return_type_id = verified_core_render_safe::vcs_return_type_id(program, function_index)
+    if return_vt < 0 || return_type_id < 0 {
+        return ""
+    }
+    let name = verified_core_render_safe::vcs_function_name(program, function_index)
+    if len(clone(name)) == 0 ||
+       !verified_core_render_safe::vcs_parameters_are_valid(program, function_index) {
+        return ""
+    }
+
+    let mut out = concat("{\"id\":", to_string(function_index))
+    out = concat(
+        out,
+        concat(",\"name\":", verified_core_render_primitives::vc_quote(name))
+    )
+    out = concat(out, ",\"signature\":{\"parameters\":[")
+    out = concat(
+        out,
+        verified_core_render_safe::vcs_render_signature_parameters(program, function_index)
+    )
+    out = concat(
+        out,
+        concat("],\"return_type_id\":", concat(to_string(return_type_id), "}"))
+    )
+    out = concat(
+        out,
+        ",\"abi\":{\"calling_convention\":\"arukellt\",\"parameters\":["
+    )
+    out = concat(
+        out,
+        verified_core_render_safe::vcs_render_abi_parameters(program, function_index)
+    )
+    out = concat(out, "],\"results\":[")
+    if return_vt != value_types::VT_VOID() {
+        out = concat(
+            out,
+            verified_core_render_primitives::vc_render_abi_item(return_type_id, return_vt)
+        )
+    }
+    out = concat(out, "]}")
+    out = concat(out, ",\"locals\":[")
+    out = concat(
+        out,
+        verified_core_render_safe::vcs_render_parameter_locals(program, function_index)
+    )
+    out = concat(out, "],\"contracts\":[")
+    out = concat(out, tccr_render_contracts(program, function_index))
+    out = concat(out, "]")
+    out = concat(out, concat(",\"body\":{\"root_expr_id\":", to_string(root)))
+    out = concat(out, ",\"expressions\":[")
+    out = concat(out, verified_core_render_safe::vcs_render_expressions(program, reachable))
+    out = concat(out, "]}}")
+    out
+}

--- a/src/compiler/driver/typed_corehir_render.ark
+++ b/src/compiler/driver/typed_corehir_render.ark
@@ -3,9 +3,9 @@ use corehir::raw_decls
 use corehir::raw_dto
 use corehir::raw_record
 use driver::config_record
+use driver::typed_corehir_contract_render
 use driver::typed_corehir_render_diagnostics
 use driver::verified_core_render_primitives
-use driver::verified_core_render_safe
 use std::host::stdio
 
 fn typed_corehir_main_module_index(program: CoreHirRawProgram) -> i32 {
@@ -26,6 +26,22 @@ fn typed_corehir_main_module_index(program: CoreHirRawProgram) -> i32 {
         module_index = module_index + 1
     }
     0 - 1
+}
+
+fn typed_corehir_render_type(type_id: i32, pointer_width: i32) -> String {
+    let rendered = verified_core_render_primitives::vc_render_type(type_id, pointer_width)
+    if type_id != 1 && type_id != 3 && type_id != 4 {
+        return rendered
+    }
+    let bits = if type_id == 4 { 64 } else { 32 }
+    let n = len(rendered)
+    if n < 1 {
+        return rendered
+    }
+    concat(
+        substring(rendered, 0, n - 1),
+        concat(",\"bits\":", concat(to_string(bits), ",\"signed\":true}"))
+    )
 }
 
 fn render_typed_corehir(program: CoreHirRawProgram, config: DriverConfig) -> String {
@@ -55,7 +71,7 @@ fn render_typed_corehir(program: CoreHirRawProgram, config: DriverConfig) -> Str
         if type_id > 0 {
             out = concat(out, ",")
         }
-        out = concat(out, verified_core_render_primitives::vc_render_type(type_id, pointer_width))
+        out = concat(out, typed_corehir_render_type(type_id, pointer_width))
         type_id = type_id + 1
     }
     out = concat(out, "],\"functions\":[")
@@ -66,7 +82,7 @@ fn render_typed_corehir(program: CoreHirRawProgram, config: DriverConfig) -> Str
     while function_index < len(fn_infos) {
         let decl_index = fn_info::fn_info_decl_index_at(fn_infos, function_index, 0 - 1)
         if decl_index >= source_decl_start && decl_index < source_decl_end {
-            let rendered = verified_core_render_safe::vcs_render_function(program, function_index)
+            let rendered = typed_corehir_contract_render::render_function(program, function_index)
             if len(clone(rendered)) == 0 {
                 stdio::eprintln(
                     typed_corehir_render_diagnostics::diagnose_typed_corehir_rejection(program)

--- a/src/compiler/driver/typed_corehir_render_diagnostics.ark
+++ b/src/compiler/driver/typed_corehir_render_diagnostics.ark
@@ -121,5 +121,5 @@ fn diagnose_typed_corehir_rejection(program: CoreHirRawProgram) -> String {
     if source_function_count == 0 {
         return "TypedCoreHIR reject: no functions in entry source module"
     }
-    "TypedCoreHIR reject: renderer returned empty after preconditions"
+    "TypedCoreHIR reject: contract renderer returned empty after preconditions"
 }

--- a/src/compiler/lexer/keywords_decl.ark
+++ b/src/compiler/lexer/keywords_decl.ark
@@ -25,6 +25,9 @@ pub fn keyword_kind_decl(word: String) -> i32 {
     if eq(word, "const") {
         return tokens::TK_CONST()
     }
+    if eq(word, "proof") {
+        return tokens::TK_PROOF()
+    }
     if eq(word, "resource") {
         return tokens::TK_RESOURCE()
     }

--- a/src/compiler/lexer/tokens.ark
+++ b/src/compiler/lexer/tokens.ark
@@ -40,6 +40,7 @@ pub fn TK_ENUM() -> i32 { 12 }
 pub fn TK_TRAIT() -> i32 { 28 }
 pub fn TK_IMPL() -> i32 { 29 }
 pub fn TK_CONST() -> i32 { 35 }
+pub fn TK_PROOF() -> i32 { 36 }
 
 // kind_keyword_loop
 pub fn TK_WHILE() -> i32 { 18 }
@@ -114,6 +115,7 @@ test mod "tokens" {
     test "ident" { assert(TK_IDENT() == 1) }
     test "eof" { assert(TK_EOF() == 0) }
     test "fn" { assert(TK_FN() == 10) }
+    test "proof" { assert(TK_PROOF() == 36) }
     test "eqeq" { assert(TK_EQEQ() == 46) }
     test "plus" { assert(TK_PLUS() == 40) }
 }

--- a/src/compiler/parser/fn_sig_decl.ark
+++ b/src/compiler/parser/fn_sig_decl.ark
@@ -7,6 +7,7 @@ use parser::core_api_expect
 use parser::fn_params_regular
 use parser::fn_return
 use parser::kinds
+use parser::proof_contracts
 use parser::token_state
 use parser::type_params
 use parser::type_where
@@ -22,6 +23,8 @@ fn parse_fn_decl_header(p: Parser) -> AstNode {
     core_api_cursor::skip_newlines(p)
     type_where::parse_optional_where_clause_stub(p)
     fn_return::parse_fn_return_annotation_into_node(p, node)
+    core_api_cursor::skip_newlines(p)
+    proof_contracts::parse_proof_contract_block(p, node)
     core_api_cursor::skip_newlines(p)
     node
 }

--- a/src/compiler/parser/kinds.ark
+++ b/src/compiler/parser/kinds.ark
@@ -79,9 +79,10 @@ fn NK_TYPE_TUPLE() -> i32 { 93 }
 fn NK_TYPE_OPTION() -> i32 { 94 }
 fn NK_TYPE_RESULT() -> i32 { 95 }
 
-// Error recovery AST node kinds (#566).
+// Error recovery and proof metadata kinds.
 fn NK_ERROR() -> i32 { 96 }
 fn NK_MISSING() -> i32 { 97 }
+fn NK_PROOF_CONTRACT() -> i32 { 98 }
 
 // Arithmetic operator kinds.
 fn OP_ADD() -> i32 { 1 }

--- a/src/compiler/parser/proof_contracts.ark
+++ b/src/compiler/parser/proof_contracts.ark
@@ -1,0 +1,57 @@
+use lexer::tokens
+use parser::core_api_cursor
+use parser::core_api_expect
+use parser::core_ast_children
+use parser::core_ast_factory
+use parser::core_ast_text_fields
+use parser::core_ast_type_ann
+use parser::expr
+use parser::kinds
+use parser::token_state
+
+fn parse_proof_contract_block(p: Parser, node: AstNode) -> bool {
+    core_api_cursor::skip_newlines(p)
+    if !core_api_cursor::at(p, tokens::TK_PROOF()) {
+        return true
+    }
+    core_api_cursor::bump(p)
+    core_api_cursor::skip_newlines(p)
+    core_api_expect::expect_token(p, tokens::TK_LBRACE())
+    core_api_cursor::skip_newlines(p)
+
+    while !core_api_cursor::at(p, tokens::TK_RBRACE()) && !core_api_cursor::at_eof(p) {
+        if core_api_cursor::peek_kind(p) != tokens::TK_IDENT() {
+            core_api_expect::error(p, "expected requires or ensures in proof block")
+            return false
+        }
+        let kind_token = core_api_cursor::bump(p)
+        let kind_name = token_state::Token_text(kind_token)
+        if !eq(clone(kind_name), "requires") && !eq(clone(kind_name), "ensures") {
+            core_api_expect::error(p, concat("unsupported proof contract kind: ", kind_name))
+            return false
+        }
+        core_api_cursor::skip_newlines(p)
+        core_api_expect::expect_token(p, tokens::TK_COLON())
+        core_api_cursor::skip_newlines(p)
+        let expression = expr::parse_expr(p)
+        let contract = core_ast_factory::AstNode_new(
+            kinds::NK_PROOF_CONTRACT(),
+            core_api_expect::tok_span(kind_token)
+        )
+        core_ast_text_fields::AstNode_set_text(contract, token_state::Token_text(kind_token))
+        core_ast_children::AstNode_push_child(contract, expression)
+        core_ast_type_ann::AstNode_push_type_ann(node, contract)
+        core_api_cursor::skip_newlines(p)
+        if core_api_cursor::at(p, tokens::TK_SEMI()) {
+            core_api_cursor::bump(p)
+        }
+        core_api_cursor::skip_newlines(p)
+    }
+
+    if core_api_cursor::at_eof(p) {
+        core_api_expect::error(p, "unterminated proof block")
+        return false
+    }
+    core_api_expect::expect_token(p, tokens::TK_RBRACE())
+    true
+}

--- a/src/compiler/typechecker/body.ark
+++ b/src/compiler/typechecker/body.ark
@@ -6,6 +6,7 @@ use typechecker::contract_env_record
 use typechecker::contract_fn_sig
 use typechecker::contract_type_access
 use typechecker::infer
+use typechecker::proof_contracts
 use typechecker::scope
 use typechecker::sigs
 
@@ -22,6 +23,7 @@ fn check_fn_body_with_sig(env: TypeEnv, fn_sigs: Vec<FnSig>, enum_defs: Vec<Enum
     if child_count > 0 {
         let body = ast_access::node_child_at(fn_node, child_count - 1)
         infer::check_stmt(env, scope, fn_sigs, enum_defs, body)
+        proof_contracts::check_proof_contracts(env, fn_sigs, enum_defs, fn_node, sig)
         contract_env_record::type_env_finalize_unused_bindings(env)
         let return_tag = contract_type_access::TypeInfo_tag(contract_fn_sig::FnSig_return_type(sig))
         if return_tag != commands::TY_UNKNOWN() && return_tag != commands::TY_UNIT() {

--- a/src/compiler/typechecker/kinds.ark
+++ b/src/compiler/typechecker/kinds.ark
@@ -53,9 +53,10 @@ fn NK_WHILE() -> i32 { 34 }
 fn NK_FOR() -> i32 { 36 }
 fn NK_EXPR_STMT() -> i32 { 37 }
 
-// Type annotation node kinds.
+// Type annotation and proof metadata node kinds.
 fn NK_TYPE_GENERIC() -> i32 { 91 }
 fn NK_TYPE_TUPLE() -> i32 { 93 }
+fn NK_PROOF_CONTRACT() -> i32 { 98 }
 
 // Comparison operator kinds.
 fn OP_EQ() -> i32 { 6 }

--- a/src/compiler/typechecker/proof_contracts.ark
+++ b/src/compiler/typechecker/proof_contracts.ark
@@ -1,0 +1,129 @@
+use typechecker::ast_access
+use typechecker::ast_expr_predicates
+use typechecker::body_params
+use typechecker::contract_fn_sig
+use typechecker::contract_type_access
+use typechecker::infer
+use typechecker::kinds
+use typechecker::name_display
+use typechecker::scope
+use typechecker::unify
+
+fn proof_contract_nodes(node: AstNode) -> Vec<AstNode> {
+    let contracts = Vec::new<AstNode>()
+    let count = ast_access::node_type_ann_count(node)
+    let mut i = 0
+    while i < count {
+        let ann = ast_access::node_type_ann_at(node, i)
+        if ast_access::node_kind(ann) == kinds::NK_PROOF_CONTRACT() {
+            push(contracts, ann)
+        }
+        i = i + 1
+    }
+    contracts
+}
+
+fn proof_contract_scope(node: AstNode, sig: FnSig) -> LocalScope {
+    let contract_scope = scope::LocalScope_new()
+    body_params::bind_fn_params_from_sig(contract_scope, node, sig)
+    contract_scope
+}
+
+fn proof_expression_uses_result(node: AstNode) -> bool {
+    if ast_expr_predicates::node_is_ident(node) && eq(ast_access::node_text(node), "result") {
+        return true
+    }
+    let child_count = ast_access::node_child_count(node)
+    let mut child_index = 0
+    while child_index < child_count {
+        if proof_expression_uses_result(ast_access::node_child_at(node, child_index)) {
+            return true
+        }
+        child_index = child_index + 1
+    }
+    false
+}
+
+fn proof_expression_identifiers_are_bound(
+    env: TypeEnv,
+    contract_scope: LocalScope,
+    node: AstNode
+) -> bool {
+    if ast_expr_predicates::node_is_ident(node) {
+        let name = ast_access::node_text(node)
+        let binding_type = scope::scope_lookup(contract_scope, clone(name))
+        if contract_type_access::TypeInfo_tag(binding_type) == commands::TY_UNKNOWN() {
+            unify::type_error(env, concat("unknown proof identifier: ", name))
+            return false
+        }
+    }
+    let child_count = ast_access::node_child_count(node)
+    let mut child_index = 0
+    while child_index < child_count {
+        if !proof_expression_identifiers_are_bound(
+            env,
+            contract_scope,
+            ast_access::node_child_at(node, child_index)
+        ) {
+            return false
+        }
+        child_index = child_index + 1
+    }
+    true
+}
+
+fn check_proof_contracts(
+    env: TypeEnv,
+    fn_sigs: Vec<FnSig>,
+    enum_defs: Vec<EnumInfo>,
+    node: AstNode,
+    sig: FnSig
+) {
+    let contracts = proof_contract_nodes(node)
+    let count = len(contracts)
+    if count == 0 {
+        return
+    }
+    let mut i = 0
+    while i < count {
+        let contract = get_unchecked(contracts, i)
+        let kind_name = ast_access::node_text(contract)
+        let contract_scope = proof_contract_scope(node, sig)
+        if eq(clone(kind_name), "ensures") {
+            scope::scope_define(
+                contract_scope,
+                "result",
+                contract_fn_sig::FnSig_return_type(sig)
+            )
+        }
+        if ast_access::node_child_count(contract) == 0 {
+            unify::type_error(env, concat("empty proof contract: ", kind_name))
+            i = i + 1
+            continue
+        }
+        let expression = ast_access::node_child_at(contract, 0)
+        if eq(clone(kind_name), "requires") && proof_expression_uses_result(expression) {
+            unify::type_error(env, "result is only available in ensures contracts")
+            i = i + 1
+            continue
+        }
+        if !proof_expression_identifiers_are_bound(env, contract_scope, expression) {
+            i = i + 1
+            continue
+        }
+        let actual = unify::resolve_type(
+            env,
+            infer::infer_expr(env, contract_scope, fn_sigs, enum_defs, expression)
+        )
+        if contract_type_access::TypeInfo_tag(actual) != commands::TY_BOOL() {
+            unify::type_error(
+                env,
+                concat(
+                    concat("proof contract must have type bool, found ", name_display::type_display_name(actual)),
+                    concat(" in ", kind_name)
+                )
+            )
+        }
+        i = i + 1
+    }
+}

--- a/src/compiler/typechecker/sig_bounds.ark
+++ b/src/compiler/typechecker/sig_bounds.ark
@@ -1,5 +1,6 @@
 use typechecker::ast_access
 use typechecker::contract_type_param_bounds
+use typechecker::kinds
 use typechecker::types
 
 fn collect_type_param_bounds(type_ann: Vec<AstNode>) -> Vec<TypeParamBounds> {
@@ -8,12 +9,16 @@ fn collect_type_param_bounds(type_ann: Vec<AstNode>) -> Vec<TypeParamBounds> {
     let mut i = 0
     while i < ann_count {
         let ann = get_unchecked(type_ann, i)
+        if ast_access::node_kind_is(ann, kinds::NK_PROOF_CONTRACT()) {
+            i = i + 1
+            continue
+        }
         let ann_name = ast_access::node_text(ann)
         if !eq(clone(ann_name), "__return") {
             let info = contract_type_param_bounds::TypeParamBounds_new(ann_name)
-            let ann_count = ast_access::node_type_ann_count(ann)
+            let ann_bound_count = ast_access::node_type_ann_count(ann)
             let mut j = 0
-            while j < ann_count {
+            while j < ann_bound_count {
                 let bound_node = ast_access::node_type_ann_at(ann, j)
                 contract_type_param_bounds::TypeParamBounds_push_bound(info, types::resolve_type_ann_node(bound_node))
                 j = j + 1

--- a/tests/verified-core/contract_identity.ark
+++ b/tests/verified-core/contract_identity.ark
@@ -1,0 +1,8 @@
+fn identity(x: i32) -> i32 proof {
+    requires: x >= 0;
+    ensures: result >= x;
+} {
+    x
+}
+
+fn main() {}

--- a/tests/verified-core/contract_non_bool.ark
+++ b/tests/verified-core/contract_non_bool.ark
@@ -1,0 +1,7 @@
+fn invalid(x: i32) -> i32 proof {
+    requires: x + 1;
+} {
+    x
+}
+
+fn main() {}

--- a/tests/verified-core/contract_result_in_requires.ark
+++ b/tests/verified-core/contract_result_in_requires.ark
@@ -1,0 +1,7 @@
+fn invalid(x: i32) -> i32 proof {
+    requires: result >= x;
+} {
+    x
+}
+
+fn main() {}

--- a/tests/verified-core/contract_unknown_identifier.ark
+++ b/tests/verified-core/contract_unknown_identifier.ark
@@ -1,0 +1,7 @@
+fn invalid(x: i32) -> i32 proof {
+    requires: missing >= x;
+} {
+    x
+}
+
+fn main() {}


### PR DESCRIPTION
Supersedes #32 for stack integration.

This clean integration adds the source `proof { requires; ensures }` frontend and compiler-emitted contract roots without reverting the already-integrated typed VerifiedCore and SolverResult boundaries.

Key integration decisions:
- proof contracts remain structured typed expressions through CoreHIR and TypedCoreHIR
- the emitter writes explicit `bits` and `signed` metadata for integer types
- the public TypedCoreHIR validator enforces that metadata
- only reachable proof-subject types are admitted into VerifiedCore
- source type names remain identity-only
- the existing converter v2, typed SMT adapter, and SolverResult-required workflows remain authoritative
- old raw solver and structural-only SMT paths from #32 are not imported

No CI result is claimed.