### PR TITLE
refactor(corehir): integrate frozen body artifact boundary

### DIFF
--- a/.github/workflows/corehir-body-boundary.yml
+++ b/.github/workflows/corehir-body-boundary.yml
@@ -1,0 +1,30 @@
+name: CoreHIR body boundary
+
+on:
+  pull_request:
+    branches: [agent/typed-contract-frontend, agent/formal-verification-hard-gates, master]
+  workflow_dispatch:
+
+concurrency:
+  group: corehir-body-boundary-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  corehir-body-boundary:
+    name: "CoreHIR body boundary"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check frozen body boundary
+        run: python3 scripts/check/check-corehir-body-boundary.py
+
+      - name: Write hash-bound boundary receipt
+        run: python3 scripts/gen/write-corehir-body-boundary-receipt.py
+
+      - name: Upload boundary receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: corehir-body-boundary
+          path: .build/proof/corehir-body-boundary.json
+          if-no-files-found: error

--- a/release/proof-policy.json
+++ b/release/proof-policy.json
@@ -8,7 +8,7 @@
     "typed_verified_core_emission": true,
     "optimizer_translation_validation": true,
     "solver_trust_manifest": true,
-    "legacy_mutable_table_removed": false,
+    "legacy_mutable_table_removed": true,
     "proof_receipt_release_enforced": true
   },
   "artifacts": []

--- a/scripts/check/check-corehir-body-boundary.py
+++ b/scripts/check/check-corehir-body-boundary.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Enforce the versioned builder-to-frozen CoreHIR body boundary."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPILER = ROOT / "src" / "compiler"
+BODY_TABLE = COMPILER / "corehir" / "body_table.ark"
+BODY_BUILDER = COMPILER / "corehir" / "body_builder.ark"
+BODY_VALIDATOR = COMPILER / "corehir" / "body_validator.ark"
+MIR_BODY_SOURCE = COMPILER / "corehir" / "mir_body_source.ark"
+ALLOWED_BUILDER_IMPORTS = {
+    "src/compiler/corehir/body.ark",
+    "src/compiler/corehir/body_roots.ark",
+}
+STORAGE_FIELDS = (
+    "exprs",
+    "fn_body_roots",
+    "method_body_roots",
+    "fn_contract_starts",
+    "fn_contract_counts",
+    "contract_roots",
+    "contract_kinds",
+    "contract_result_names",
+)
+FORBIDDEN_READ_API_TOKENS = (
+    "CoreHirBodyTable_new",
+    "corehir_body_table_push_",
+    "corehir_body_table_begin_",
+    "corehir_body_table_end_",
+    "push(table.",
+    "fn corehir_body_table_fn_body_roots",
+    "fn corehir_body_table_method_body_roots",
+)
+FORBIDDEN_VECTOR_FACADE_TOKENS = (
+    "fn body_exprs(",
+    "fn body_fn_roots(",
+    "fn body_method_roots(",
+    "body::body_exprs(",
+    "body::body_fn_roots(",
+    "body::body_method_roots(",
+)
+
+
+def relative(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def require(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise ValueError(f"missing {label}: {needle}")
+
+
+def main() -> int:
+    table = BODY_TABLE.read_text(encoding="utf-8")
+    builder = BODY_BUILDER.read_text(encoding="utf-8")
+    validator = BODY_VALIDATOR.read_text(encoding="utf-8")
+    mir_body_source = MIR_BODY_SOURCE.read_text(encoding="utf-8")
+
+    require(table, "struct CoreHirBodyTable", "frozen body artifact record")
+    require(table, "schema_version: i32", "body artifact schema version field")
+    require(table, "fn corehir_body_table_schema_version", "schema accessor")
+    require(table, "fn corehir_body_table_expr_count", "expression count accessor")
+    require(table, "fn corehir_body_table_expr_at", "expression indexed accessor")
+    for token in FORBIDDEN_READ_API_TOKENS:
+        if token in table:
+            raise ValueError(f"body_table exposes mutation or storage alias: {token}")
+
+    # The compatibility Vec API is permitted only as a detached deep snapshot.
+    require(table, "fn corehir_body_table_exprs", "detached renderer snapshot")
+    require(table, "let snapshot = Vec::new<CoreHirExpr>()", "new snapshot vector")
+    require(table, "let children = Vec::new<i32>()", "new children vector")
+    require(table, "expr_factory::CoreHirExpr_new", "expression reconstruction")
+    if "snapshot = table.exprs" in table or "return table.exprs" in table:
+        raise ValueError("body_table expression snapshot aliases frozen storage")
+
+    require(builder, "fn CoreHirBodyBuilder_new", "construction capability")
+    require(builder, "schema_version: 1", "artifact v1 construction")
+    require(builder, "fn corehir_body_builder_finish", "builder handoff")
+    require(
+        builder,
+        "body_validator::corehir_body_artifact_valid(builder)",
+        "independent validator invocation",
+    )
+    require(builder, "process::exit(1)", "fail-closed invalid artifact action")
+
+    require(validator, "fn corehir_body_artifact_valid", "artifact validator")
+    require(
+        validator,
+        "corehir_body_table_schema_version(table) != 1",
+        "schema validation",
+    )
+    require(
+        validator,
+        "expected_start != flat_contract_count",
+        "contract range coverage",
+    )
+    require(validator, "root < 0 || root >= expr_count", "contract root validation")
+
+    require(mir_body_source, "fn mir_body_source_copy_expr", "detached MIR expression copy")
+    require(mir_body_source, "let exprs = Vec::new<CoreHirExpr>()", "detached MIR vector")
+    require(mir_body_source, "let children = Vec::new<i32>()", "detached MIR children")
+    require(mir_body_source, "corehir_body_expr_count(table)", "count-based snapshot")
+    require(mir_body_source, "corehir_body_expr_at(table, expr_index)", "indexed snapshot")
+
+    violations: list[str] = []
+    for path in sorted(COMPILER.rglob("*.ark")):
+        rel = relative(path)
+        text = path.read_text(encoding="utf-8")
+        if "use corehir::body_builder" in text and rel not in ALLOWED_BUILDER_IMPORTS:
+            violations.append(f"{rel}: imports construction-only body_builder")
+        if rel != "src/compiler/corehir/body_builder.ark":
+            for field in STORAGE_FIELDS:
+                for prefix in ("push(table.", "push(builder.", "set(table.", "set(builder."):
+                    if f"{prefix}{field}" in text:
+                        violations.append(f"{rel}: directly mutates body storage field {field}")
+        for token in FORBIDDEN_VECTOR_FACADE_TOKENS:
+            if token in text:
+                violations.append(f"{rel}: exposes or consumes body storage vector: {token}")
+
+    for prefix in ("src/compiler/driver/", "src/compiler/mir/", "src/compiler/wasm/"):
+        for path in sorted((ROOT / prefix).rglob("*.ark")):
+            text = path.read_text(encoding="utf-8")
+            for token in (
+                "body_builder::",
+                "corehir_body_builder_",
+                "corehir_push_expr(",
+                "corehir_push_fn_body_root(",
+                "corehir_push_method_body_root(",
+            ):
+                if token in text:
+                    violations.append(f"{relative(path)}: downstream mutation token {token}")
+
+    if violations:
+        raise ValueError("\n".join(violations))
+    print(
+        "corehir-body-boundary: PASS: version=1 builder -> validator -> "
+        "frozen artifact -> detached snapshots"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"corehir-body-boundary: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/write-corehir-body-boundary-receipt.py
+++ b/scripts/gen/write-corehir-body-boundary-receipt.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Write a hash-bound receipt for the frozen CoreHIR body boundary."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = "scripts/check/check-corehir-body-boundary.py"
+COMPONENTS = (
+    ("artifact", "src/compiler/corehir/body_table.ark"),
+    ("builder", "src/compiler/corehir/body_builder.ark"),
+    ("validator", "src/compiler/corehir/body_validator.ark"),
+    ("construction_facade", "src/compiler/corehir/body.ark"),
+    ("construction_handoff", "src/compiler/corehir/body_roots.ark"),
+    ("detached_mir_snapshot", "src/compiler/corehir/mir_body_source.ark"),
+    ("static_boundary_gate", CHECKER),
+)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "corehir-body-boundary.json",
+    )
+    args = parser.parse_args()
+
+    subprocess.run([sys.executable, str(ROOT / CHECKER)], cwd=ROOT, check=True)
+    components: list[dict[str, str]] = []
+    for role, relative in COMPONENTS:
+        path = ROOT / relative
+        if not path.is_file():
+            raise ValueError(f"boundary component missing: {relative}")
+        components.append({"role": role, "path": relative, "sha256": sha256(path)})
+
+    document = {
+        "schema": "arukellt-corehir-body-boundary-receipt",
+        "schema_version": 1,
+        "artifact_schema_version": 1,
+        "status": "enforced",
+        "construction_policy": {
+            "mutation_owner": "src/compiler/corehir/body_builder.ark",
+            "handoff": "corehir_body_builder_finish",
+            "invalid_artifact_action": "compiler-ice",
+        },
+        "consumption_policy": {
+            "artifact_api": "count/index accessors; compatibility snapshots are deep copies",
+            "storage_vector_aliases": "forbidden",
+            "renderer_handoff": "detached deep snapshot",
+            "mir_handoff": "detached deep snapshot",
+        },
+        "components": components,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"corehir-body-boundary-receipt: PASS: output={args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, subprocess.CalledProcessError, ValueError) as exc:
+        print(f"corehir-body-boundary-receipt: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/src/compiler/corehir/body.ark
+++ b/src/compiler/corehir/body.ark
@@ -1,4 +1,5 @@
 use corehir::expr_factory
+use corehir::body_builder
 use corehir::body_expr_dispatch
 use corehir::body_support
 use corehir::body_stmt_dispatch
@@ -6,11 +7,15 @@ use corehir::body_table
 use corehir::expr_node_access
 
 fn CoreHirBodyTable_new() -> CoreHirBodyTable {
-    body_table::CoreHirBodyTable_new()
+    body_builder::CoreHirBodyBuilder_new()
 }
 
 fn corehir_push_expr(table: CoreHirBodyTable, expr: CoreHirExpr) -> i32 {
-    body_table::corehir_body_table_push_expr(table, expr)
+    body_builder::corehir_body_builder_push_expr(table, expr)
+}
+
+fn corehir_body_expr_count(table: CoreHirBodyTable) -> i32 {
+    body_table::corehir_body_table_expr_count(table)
 }
 
 fn corehir_body_expr_at(table: CoreHirBodyTable, index: i32) -> CoreHirExpr {
@@ -18,11 +23,11 @@ fn corehir_body_expr_at(table: CoreHirBodyTable, index: i32) -> CoreHirExpr {
 }
 
 fn corehir_push_fn_body_root(table: CoreHirBodyTable, root: i32) {
-    body_table::corehir_body_table_push_fn_body_root(table, root)
+    body_builder::corehir_body_builder_push_fn_body_root(table, root)
 }
 
 fn corehir_push_method_body_root(table: CoreHirBodyTable, root: i32) {
-    body_table::corehir_body_table_push_method_body_root(table, root)
+    body_builder::corehir_body_builder_push_method_body_root(table, root)
 }
 
 fn corehir_fn_body_root_count(table: CoreHirBodyTable) -> i32 {
@@ -51,18 +56,6 @@ fn corehir_build_expr(table: CoreHirBodyTable, node: AstNode) -> i32 {
         return stmt_result
     }
     corehir_push_expr(table, expr_factory::CoreHirExpr_unsupported(expr_node_access::expr_span_start(node)))
-}
-
-fn body_exprs(table: CoreHirBodyTable) -> Vec<CoreHirExpr> {
-    body_table::corehir_body_table_exprs(table)
-}
-
-fn body_fn_roots(table: CoreHirBodyTable) -> Vec<i32> {
-    body_table::corehir_body_table_fn_body_roots(table)
-}
-
-fn body_method_roots(table: CoreHirBodyTable) -> Vec<i32> {
-    body_table::corehir_body_table_method_body_roots(table)
 }
 
 fn expr_tree_is_supported(exprs: Vec<CoreHirExpr>, root: i32) -> bool {

--- a/src/compiler/corehir/body_builder.ark
+++ b/src/compiler/corehir/body_builder.ark
@@ -1,0 +1,64 @@
+use std::host::process
+use std::host::stdio
+use corehir::body_table
+use corehir::body_validator
+
+// Construction-only capability. This module is owned by the frontend CoreHIR
+// builder and must not be imported by MIR, backend, or artifact renderers.
+fn CoreHirBodyBuilder_new() -> CoreHirBodyTable {
+    CoreHirBodyTable {
+        schema_version: 1,
+        exprs: Vec::new<CoreHirExpr>(),
+        fn_body_roots: Vec::new<i32>(),
+        method_body_roots: Vec::new<i32>(),
+        fn_contract_starts: Vec::new<i32>(),
+        fn_contract_counts: Vec::new<i32>(),
+        contract_roots: Vec::new<i32>(),
+        contract_kinds: Vec::new<String>(),
+        contract_result_names: Vec::new<String>(),
+    }
+}
+
+fn corehir_body_builder_push_expr(builder: CoreHirBodyTable, expr: CoreHirExpr) -> i32 {
+    let index = len(builder.exprs)
+    push(builder.exprs, expr)
+    index
+}
+
+fn corehir_body_builder_push_fn_body_root(builder: CoreHirBodyTable, root: i32) {
+    push(builder.fn_body_roots, root)
+}
+
+fn corehir_body_builder_push_method_body_root(builder: CoreHirBodyTable, root: i32) {
+    push(builder.method_body_roots, root)
+}
+
+fn corehir_body_builder_begin_fn_contracts(builder: CoreHirBodyTable) -> i32 {
+    len(builder.contract_roots)
+}
+
+fn corehir_body_builder_push_fn_contract(
+    builder: CoreHirBodyTable,
+    root: i32,
+    kind: String,
+    result_name: String
+) {
+    push(builder.contract_roots, root)
+    push(builder.contract_kinds, kind)
+    push(builder.contract_result_names, result_name)
+}
+
+fn corehir_body_builder_end_fn_contracts(builder: CoreHirBodyTable, start: i32) {
+    push(builder.fn_contract_starts, start)
+    push(builder.fn_contract_counts, len(builder.contract_roots) - start)
+}
+
+// Explicit fail-closed handoff from construction capability to the frozen
+// read-only artifact boundary.
+fn corehir_body_builder_finish(builder: CoreHirBodyTable) -> CoreHirBodyTable {
+    if !body_validator::corehir_body_artifact_valid(builder) {
+        stdio::eprintln(String_from("compiler ICE: invalid CoreHIR body artifact v1"))
+        process::exit(1)
+    }
+    builder
+}

--- a/src/compiler/corehir/body_roots.ark
+++ b/src/compiler/corehir/body_roots.ark
@@ -1,13 +1,13 @@
 use corehir::body
-use corehir::body_table
+use corehir::body_builder
 use corehir::decl_children
 use corehir::decl_member_collections
 use corehir::decl_node
 use corehir::frontend_ast_node
 use corehir::frontend_kind_map
 
-fn lower_fn_contracts(table: CoreHirBodyTable, decl: AstNode) -> i32 {
-    let start = body_table::corehir_body_table_begin_fn_contracts(table)
+fn lower_fn_contracts(builder: CoreHirBodyTable, decl: AstNode) -> i32 {
+    let start = body_builder::corehir_body_builder_begin_fn_contracts(builder)
     let annotation_count = frontend_ast_node::corehir_node_type_ann_count(decl)
     let mut annotation_index = 0
     while annotation_index < annotation_count {
@@ -16,15 +16,15 @@ fn lower_fn_contracts(table: CoreHirBodyTable, decl: AstNode) -> i32 {
             let child_count = frontend_ast_node::corehir_node_child_count(annotation)
             if child_count == 1 {
                 let expression = frontend_ast_node::corehir_node_child_at(annotation, 0)
-                let root = corehir_build_expr(table, expression)
+                let root = corehir_build_expr(builder, expression)
                 let kind = frontend_ast_node::corehir_node_text(annotation)
                 let result_name = if eq(clone(kind), "ensures") {
                     "result"
                 } else {
                     ""
                 }
-                body_table::corehir_body_table_push_fn_contract(
-                    table,
+                body_builder::corehir_body_builder_push_fn_contract(
+                    builder,
                     root,
                     kind,
                     result_name
@@ -37,20 +37,20 @@ fn lower_fn_contracts(table: CoreHirBodyTable, decl: AstNode) -> i32 {
 }
 
 fn build_body_table(decls: Vec<AstNode>) -> CoreHirBodyTable {
-    let table = body::CoreHirBodyTable_new()
+    let builder = body::CoreHirBodyTable_new()
     let decl_count = len(decls)
     let mut i = 0
     while i < decl_count {
         let decl = get_unchecked(decls, i)
         if decl_node::decl_is_fn(decl) {
-            let contract_start = lower_fn_contracts(table, decl)
+            let contract_start = lower_fn_contracts(builder, decl)
             let body_idx = decl_children::decl_body_index(decl)
             let mut root = 0 - 1
             if body_idx >= 0 {
-                root = corehir_build_expr(table, decl_children::decl_child_at(decl, body_idx))
+                root = corehir_build_expr(builder, decl_children::decl_child_at(decl, body_idx))
             }
-            corehir_push_fn_body_root(table, root)
-            body_table::corehir_body_table_end_fn_contracts(table, contract_start)
+            corehir_push_fn_body_root(builder, root)
+            body_builder::corehir_body_builder_end_fn_contracts(builder, contract_start)
         }
         if decl_node::decl_is_impl(decl) {
             let method_count = decl_member_collections::decl_method_count(decl)
@@ -60,15 +60,15 @@ fn build_body_table(decls: Vec<AstNode>) -> CoreHirBodyTable {
                 let body_idx = decl_member_collections::method_body_index(method)
                 let mut root = 0 - 1
                 if body_idx >= 0 {
-                    root = corehir_build_expr(table, decl_children::decl_child_at(method, body_idx))
+                    root = corehir_build_expr(builder, decl_children::decl_child_at(method, body_idx))
                 }
-                corehir_push_method_body_root(table, root)
+                corehir_push_method_body_root(builder, root)
                 mi = mi + 1
             }
         }
         i = i + 1
     }
-    table
+    body_builder::corehir_body_builder_finish(builder)
 }
 
 fn fn_body_root(table: CoreHirBodyTable, fn_info_index: i32) -> i32 {

--- a/src/compiler/corehir/body_table.ark
+++ b/src/compiler/corehir/body_table.ark
@@ -1,4 +1,10 @@
+use corehir::expr_factory
+use corehir::expr_raw
+
+// Frozen versioned CoreHIR body artifact. Mutation is owned exclusively by
+// body_builder and the completed artifact is validated by body_validator.
 struct CoreHirBodyTable {
+    schema_version: i32,
     exprs: Vec<CoreHirExpr>,
     fn_body_roots: Vec<i32>,
     method_body_roots: Vec<i32>,
@@ -9,35 +15,47 @@ struct CoreHirBodyTable {
     contract_result_names: Vec<String>,
 }
 
-fn CoreHirBodyTable_new() -> CoreHirBodyTable {
-    CoreHirBodyTable {
-        exprs: Vec::new<CoreHirExpr>(),
-        fn_body_roots: Vec::new<i32>(),
-        method_body_roots: Vec::new<i32>(),
-        fn_contract_starts: Vec::new<i32>(),
-        fn_contract_counts: Vec::new<i32>(),
-        contract_roots: Vec::new<i32>(),
-        contract_kinds: Vec::new<String>(),
-        contract_result_names: Vec::new<String>(),
-    }
+fn corehir_body_table_schema_version(table: CoreHirBodyTable) -> i32 {
+    table.schema_version
 }
 
-fn corehir_body_table_push_expr(table: CoreHirBodyTable, expr: CoreHirExpr) -> i32 {
-    let idx = len(table.exprs)
-    push(table.exprs, expr)
-    idx
+fn corehir_body_table_expr_count(table: CoreHirBodyTable) -> i32 {
+    len(table.exprs)
 }
 
 fn corehir_body_table_expr_at(table: CoreHirBodyTable, index: i32) -> CoreHirExpr {
     get_unchecked(table.exprs, index)
 }
 
-fn corehir_body_table_push_fn_body_root(table: CoreHirBodyTable, root: i32) {
-    push(table.fn_body_roots, root)
-}
-
-fn corehir_body_table_push_method_body_root(table: CoreHirBodyTable, root: i32) {
-    push(table.method_body_roots, root)
+// Compatibility for proof renderers. This is not an alias to frozen storage:
+// every expression and every children vector is reconstructed into a new Vec.
+fn corehir_body_table_exprs(table: CoreHirBodyTable) -> Vec<CoreHirExpr> {
+    let snapshot = Vec::new<CoreHirExpr>()
+    let mut index = 0
+    while index < corehir_body_table_expr_count(table) {
+        let expr = corehir_body_table_expr_at(table, index)
+        let children = Vec::new<i32>()
+        let mut child_index = 0
+        while child_index < expr_raw::corehir_expr_child_count(expr) {
+            push(children, expr_raw::corehir_expr_child(expr, child_index))
+            child_index = child_index + 1
+        }
+        push(
+            snapshot,
+            expr_factory::CoreHirExpr_new(
+                expr_raw::corehir_expr_kind(expr),
+                expr_raw::corehir_expr_text(expr),
+                expr_raw::corehir_expr_int_val(expr),
+                expr_raw::corehir_expr_float_val(expr),
+                expr_raw::corehir_expr_val_type(expr),
+                expr_raw::corehir_expr_type_name(expr),
+                expr_raw::corehir_expr_span_start(expr),
+                children
+            )
+        )
+        index = index + 1
+    }
+    snapshot
 }
 
 fn corehir_body_table_fn_body_root_count(table: CoreHirBodyTable) -> i32 {
@@ -56,26 +74,6 @@ fn corehir_body_table_method_body_root_at(table: CoreHirBodyTable, index: i32) -
     get_unchecked(table.method_body_roots, index)
 }
 
-fn corehir_body_table_begin_fn_contracts(table: CoreHirBodyTable) -> i32 {
-    len(table.contract_roots)
-}
-
-fn corehir_body_table_push_fn_contract(
-    table: CoreHirBodyTable,
-    root: i32,
-    kind: String,
-    result_name: String
-) {
-    push(table.contract_roots, root)
-    push(table.contract_kinds, kind)
-    push(table.contract_result_names, result_name)
-}
-
-fn corehir_body_table_end_fn_contracts(table: CoreHirBodyTable, start: i32) {
-    push(table.fn_contract_starts, start)
-    push(table.fn_contract_counts, len(table.contract_roots) - start)
-}
-
 fn corehir_body_table_fn_contract_count(table: CoreHirBodyTable, body_index: i32) -> i32 {
     if body_index < 0 || body_index >= len(table.fn_contract_counts) {
         return 0
@@ -83,19 +81,62 @@ fn corehir_body_table_fn_contract_count(table: CoreHirBodyTable, body_index: i32
     get_unchecked(table.fn_contract_counts, body_index)
 }
 
+fn corehir_body_table_fn_contract_start(table: CoreHirBodyTable, body_index: i32) -> i32 {
+    if body_index < 0 || body_index >= len(table.fn_contract_starts) {
+        return 0 - 1
+    }
+    get_unchecked(table.fn_contract_starts, body_index)
+}
+
 fn corehir_body_table_fn_contract_flat_index(
     table: CoreHirBodyTable,
     body_index: i32,
     contract_index: i32
 ) -> i32 {
-    if body_index < 0 || body_index >= len(table.fn_contract_starts) {
+    let start = corehir_body_table_fn_contract_start(table, body_index)
+    if start < 0 {
         return 0 - 1
     }
     let count = corehir_body_table_fn_contract_count(table, body_index)
     if contract_index < 0 || contract_index >= count {
         return 0 - 1
     }
-    get_unchecked(table.fn_contract_starts, body_index) + contract_index
+    start + contract_index
+}
+
+fn corehir_body_table_contract_flat_count(table: CoreHirBodyTable) -> i32 {
+    len(table.contract_roots)
+}
+
+fn corehir_body_table_contract_root_flat_at(table: CoreHirBodyTable, index: i32) -> i32 {
+    get_unchecked(table.contract_roots, index)
+}
+
+fn corehir_body_table_contract_kind_flat_at(table: CoreHirBodyTable, index: i32) -> String {
+    clone(get_unchecked(table.contract_kinds, index))
+}
+
+fn corehir_body_table_contract_result_name_flat_at(
+    table: CoreHirBodyTable,
+    index: i32
+) -> String {
+    clone(get_unchecked(table.contract_result_names, index))
+}
+
+fn corehir_body_table_contract_kind_count(table: CoreHirBodyTable) -> i32 {
+    len(table.contract_kinds)
+}
+
+fn corehir_body_table_contract_result_name_count(table: CoreHirBodyTable) -> i32 {
+    len(table.contract_result_names)
+}
+
+fn corehir_body_table_fn_contract_range_count(table: CoreHirBodyTable) -> i32 {
+    len(table.fn_contract_starts)
+}
+
+fn corehir_body_table_fn_contract_count_record_count(table: CoreHirBodyTable) -> i32 {
+    len(table.fn_contract_counts)
 }
 
 fn corehir_body_table_fn_contract_root_at(
@@ -107,7 +148,7 @@ fn corehir_body_table_fn_contract_root_at(
     if flat_index < 0 {
         return 0 - 1
     }
-    get_unchecked(table.contract_roots, flat_index)
+    corehir_body_table_contract_root_flat_at(table, flat_index)
 }
 
 fn corehir_body_table_fn_contract_kind_at(
@@ -119,7 +160,7 @@ fn corehir_body_table_fn_contract_kind_at(
     if flat_index < 0 {
         return String_new()
     }
-    clone(get_unchecked(table.contract_kinds, flat_index))
+    corehir_body_table_contract_kind_flat_at(table, flat_index)
 }
 
 fn corehir_body_table_fn_contract_result_name_at(
@@ -131,17 +172,5 @@ fn corehir_body_table_fn_contract_result_name_at(
     if flat_index < 0 {
         return String_new()
     }
-    clone(get_unchecked(table.contract_result_names, flat_index))
-}
-
-fn corehir_body_table_exprs(table: CoreHirBodyTable) -> Vec<CoreHirExpr> {
-    table.exprs
-}
-
-fn corehir_body_table_fn_body_roots(table: CoreHirBodyTable) -> Vec<i32> {
-    table.fn_body_roots
-}
-
-fn corehir_body_table_method_body_roots(table: CoreHirBodyTable) -> Vec<i32> {
-    table.method_body_roots
+    corehir_body_table_contract_result_name_flat_at(table, flat_index)
 }

--- a/src/compiler/corehir/body_validator.ark
+++ b/src/compiler/corehir/body_validator.ark
@@ -1,0 +1,86 @@
+use corehir::body_table
+
+fn corehir_body_artifact_root_valid(table: CoreHirBodyTable, root: i32) -> bool {
+    root == 0 - 1 ||
+    (root >= 0 && root < body_table::corehir_body_table_expr_count(table))
+}
+
+fn corehir_body_artifact_valid(table: CoreHirBodyTable) -> bool {
+    if body_table::corehir_body_table_schema_version(table) != 1 {
+        return false
+    }
+    let expr_count = body_table::corehir_body_table_expr_count(table)
+    let fn_count = body_table::corehir_body_table_fn_body_root_count(table)
+    let method_count = body_table::corehir_body_table_method_body_root_count(table)
+    let flat_contract_count = body_table::corehir_body_table_contract_flat_count(table)
+
+    if body_table::corehir_body_table_fn_contract_range_count(table) != fn_count ||
+       body_table::corehir_body_table_fn_contract_count_record_count(table) != fn_count {
+        return false
+    }
+    if body_table::corehir_body_table_contract_kind_count(table) != flat_contract_count ||
+       body_table::corehir_body_table_contract_result_name_count(table) != flat_contract_count {
+        return false
+    }
+
+    let mut i = 0
+    while i < fn_count {
+        if !corehir_body_artifact_root_valid(
+            table,
+            body_table::corehir_body_table_fn_body_root_at(table, i)
+        ) {
+            return false
+        }
+        i = i + 1
+    }
+    i = 0
+    while i < method_count {
+        if !corehir_body_artifact_root_valid(
+            table,
+            body_table::corehir_body_table_method_body_root_at(table, i)
+        ) {
+            return false
+        }
+        i = i + 1
+    }
+
+    let mut expected_start = 0
+    i = 0
+    while i < fn_count {
+        let start = body_table::corehir_body_table_fn_contract_start(table, i)
+        let count = body_table::corehir_body_table_fn_contract_count(table, i)
+        if start != expected_start || count < 0 || start + count > flat_contract_count {
+            return false
+        }
+        expected_start = start + count
+        i = i + 1
+    }
+    if expected_start != flat_contract_count {
+        return false
+    }
+
+    i = 0
+    while i < flat_contract_count {
+        let root = body_table::corehir_body_table_contract_root_flat_at(table, i)
+        if root < 0 || root >= expr_count {
+            return false
+        }
+        let kind = body_table::corehir_body_table_contract_kind_flat_at(table, i)
+        let result_name = body_table::corehir_body_table_contract_result_name_flat_at(table, i)
+        if eq(clone(kind), "requires") {
+            if len(result_name) != 0 {
+                return false
+            }
+        } else {
+            if eq(clone(kind), "ensures") {
+                if !eq(result_name, "result") {
+                    return false
+                }
+            } else {
+                return false
+            }
+        }
+        i = i + 1
+    }
+    true
+}

--- a/src/compiler/corehir/mir_body_source.ark
+++ b/src/compiler/corehir/mir_body_source.ark
@@ -1,4 +1,6 @@
 use corehir::body
+use corehir::expr_factory
+use corehir::expr_raw
 
 struct CoreHirMirBodySource {
     exprs: Vec<CoreHirExpr>,
@@ -6,11 +8,58 @@ struct CoreHirMirBodySource {
     method_body_roots: Vec<i32>,
 }
 
+fn mir_body_source_copy_expr(expr: CoreHirExpr) -> CoreHirExpr {
+    let children = Vec::new<i32>()
+    let child_count = expr_raw::corehir_expr_child_count(expr)
+    let mut child_index = 0
+    while child_index < child_count {
+        push(children, expr_raw::corehir_expr_child(expr, child_index))
+        child_index = child_index + 1
+    }
+    expr_factory::CoreHirExpr_new(
+        expr_raw::corehir_expr_kind(expr),
+        expr_raw::corehir_expr_text(expr),
+        expr_raw::corehir_expr_int_val(expr),
+        expr_raw::corehir_expr_float_val(expr),
+        expr_raw::corehir_expr_val_type(expr),
+        expr_raw::corehir_expr_type_name(expr),
+        expr_raw::corehir_expr_span_start(expr),
+        children
+    )
+}
+
 fn mir_body_source_from_table(table: CoreHirBodyTable) -> CoreHirMirBodySource {
+    let exprs = Vec::new<CoreHirExpr>()
+    let mut expr_index = 0
+    while expr_index < body::corehir_body_expr_count(table) {
+        push(
+            exprs,
+            mir_body_source_copy_expr(body::corehir_body_expr_at(table, expr_index))
+        )
+        expr_index = expr_index + 1
+    }
+
+    let fn_body_roots = Vec::new<i32>()
+    let mut fn_index = 0
+    while fn_index < body::corehir_fn_body_root_count(table) {
+        push(fn_body_roots, body::corehir_fn_body_root_at(table, fn_index))
+        fn_index = fn_index + 1
+    }
+
+    let method_body_roots = Vec::new<i32>()
+    let mut method_index = 0
+    while method_index < body::corehir_method_body_root_count(table) {
+        push(
+            method_body_roots,
+            body::corehir_method_body_root_at(table, method_index)
+        )
+        method_index = method_index + 1
+    }
+
     CoreHirMirBodySource {
-        exprs: body::body_exprs(table),
-        fn_body_roots: body::body_fn_roots(table),
-        method_body_roots: body::body_method_roots(table),
+        exprs: exprs,
+        fn_body_roots: fn_body_roots,
+        method_body_roots: method_body_roots,
     }
 }
 


### PR DESCRIPTION
Supersedes #35 for stack integration.

This clean integration preserves the source-contract roots added by #38 while completing the frozen CoreHIR body boundary.

Included:
- builder-only mutation capability
- schema-versioned body artifact and independent validator
- validated builder-to-artifact handoff
- count/index accessors for frozen storage
- detached deep-copy MIR snapshot
- detached deep-copy compatibility snapshot for proof renderers; no internal Vec alias is returned
- static reintroduction gate and hash-bound receipt
- `legacy_mutable_table_removed=true` while preserving every previously enabled hard gate

The compatibility snapshot exists to keep current renderers compiling, but reconstructs every expression and children vector. No CI result is claimed.