### PR TITLE
feat(proof): integrate proof release authorization and boundary registry

### DIFF
--- a/.github/workflows/proof-required-release.yml
+++ b/.github/workflows/proof-required-release.yml
@@ -29,21 +29,28 @@ jobs:
             *) echo "proof-required release requires refs/tags/v*" >&2; exit 1 ;;
           esac
 
-      - name: Reject unguarded release and boundary entrypoints
+      - name: Reject unguarded entrypoints
         run: |
           python3 scripts/check/check-proof-release-entrypoints.py
           python3 scripts/check/check-versioned-boundary-enforcement.py
+          python3 scripts/check/check-solver-trust-manifest-boundary.py
 
-      - name: Write release enforcement boundary receipt
-        run: python3 scripts/gen/write-proof-release-enforcement-receipt.py
+      - name: Write release and solver boundary receipts
+        run: |
+          python3 scripts/gen/write-proof-release-enforcement-receipt.py
+          python3 scripts/gen/write-solver-trust-boundary-receipt.py
+          python3 scripts/check/check-solver-trust-boundary-receipt.py \
+            .build/proof/solver-trust-boundary.json
 
-      - name: Validate release gate libraries
+      - name: Validate release libraries
         run: |
           python3 -m unittest \
             scripts.tests.test_boundary_registry \
             scripts.tests.test_source_proof_binding \
             scripts.tests.test_proof_required_release_gate \
-            scripts.tests.test_release_authorization
+            scripts.tests.test_release_authorization \
+            scripts.tests.test_solver_result \
+            scripts.tests.test_solver_trust_boundary_receipt
 
       - name: Install Wasmtime and Z3
         run: |
@@ -61,6 +68,17 @@ jobs:
 
       - name: Prove and authorize release payload
         run: bash scripts/run/proof-required-release.sh
+
+      - name: Independently validate SolverResult
+        run: |
+          python3 scripts/check/check-solver-result.py \
+            .build/typed-contract-proof/solver-result.json \
+            --subject .build/typed-contract-proof/verified-core.json \
+            --solver-input .build/typed-contract-proof/verified-core-vcs.smt2 \
+            --toolchain .build/proof-release-toolchain/toolchain.json \
+            --solver-output .build/typed-contract-proof/solver-output.txt \
+            --trust-manifest .build/typed-contract-proof/trust-manifest.json \
+            --proof-receipt .build/typed-contract-proof/proof-receipt.json
 
       - name: Verify publisher-side authorization
         run: |
@@ -94,6 +112,7 @@ jobs:
             release/boundary-registry.json
             .build/proof/boundary-registry-validation.json
             .build/proof/proof-release-enforcement.json
+            .build/proof/solver-trust-boundary.json
             .build/proof/backend-typeid-layout.json
             .build/proof/mir-opt-translation-registry.json
             .build/proof/corehir-body-boundary.json

--- a/.github/workflows/proof-required-release.yml
+++ b/.github/workflows/proof-required-release.yml
@@ -1,0 +1,101 @@
+name: Proof required release authorization
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: proof-required-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  authorize-release:
+    name: "Authorize exact tag and payload"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject non-tag manual invocation
+        run: |
+          case "$GITHUB_REF" in
+            refs/tags/v*) ;;
+            *) echo "proof-required release requires refs/tags/v*" >&2; exit 1 ;;
+          esac
+
+      - name: Reject unguarded release and boundary entrypoints
+        run: |
+          python3 scripts/check/check-proof-release-entrypoints.py
+          python3 scripts/check/check-versioned-boundary-enforcement.py
+
+      - name: Write release enforcement boundary receipt
+        run: python3 scripts/gen/write-proof-release-enforcement-receipt.py
+
+      - name: Validate release gate libraries
+        run: |
+          python3 -m unittest \
+            scripts.tests.test_boundary_registry \
+            scripts.tests.test_source_proof_binding \
+            scripts.tests.test_proof_required_release_gate \
+            scripts.tests.test_release_authorization
+
+      - name: Install Wasmtime and Z3
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.1
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+          sudo apt-get update
+          sudo apt-get install -y z3
+          z3 --version
+
+      - name: Build host linker
+        run: |
+          cargo build --release --quiet
+          cargo test --lib --no-run --quiet
+        working-directory: tools/host-linker
+
+      - name: Prove and authorize release payload
+        run: bash scripts/run/proof-required-release.sh
+
+      - name: Verify publisher-side authorization
+        run: |
+          python3 scripts/check/check-release-authorization.py \
+            --authorization .build/proof-required-release/release-authorization.json \
+            --repository "$GITHUB_REPOSITORY" \
+            --commit "$GITHUB_SHA" \
+            --tag "$GITHUB_REF_NAME" \
+            --policy .build/typed-contract-proof/release-policy.json \
+            --source-binding .build/typed-contract-proof/source-proof-binding.json \
+            --trust-manifest .build/typed-contract-proof/trust-manifest.json \
+            --proof-receipt .build/typed-contract-proof/proof-receipt.json \
+            --release-payload-manifest .build/proof-required-release/release-payload-manifest.json \
+            --release-payload arukellt-wasm=.build/proof-required-release/arukellt-s2-runtime.wasm
+
+      - name: Upload authorized proof release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: proof-required-release-${{ github.ref_name }}
+          path: |
+            .build/proof-required-release/release-authorization.json
+            .build/proof-required-release/release-provenance.json
+            .build/proof-required-release/release-payload-manifest.json
+            .build/proof-required-release/arukellt-s2-runtime.wasm
+            .build/typed-contract-proof/release-policy.json
+            .build/typed-contract-proof/source-proof-binding.json
+            .build/typed-contract-proof/trust-manifest.json
+            .build/typed-contract-proof/proof-receipt.json
+            .build/typed-contract-proof/solver-output.txt
+            .build/typed-contract-proof/solver-result.json
+            release/boundary-registry.json
+            .build/proof/boundary-registry-validation.json
+            .build/proof/proof-release-enforcement.json
+            .build/proof/backend-typeid-layout.json
+            .build/proof/mir-opt-translation-registry.json
+            .build/proof/corehir-body-boundary.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/typed-contract-frontend.yml
+++ b/.github/workflows/typed-contract-frontend.yml
@@ -5,6 +5,9 @@ on:
     branches: [agent/formal-verification-hard-gates, master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: typed-contract-frontend-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -15,24 +18,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Check structured and typed proof boundaries
+      - name: Check source and architecture boundaries
         run: |
           python3 scripts/check/check-typed-contract-source.py
           python3 scripts/check/check-typed-verified-core-boundary.py
           python3 scripts/check/check-solver-trust-manifest-boundary.py
+          python3 scripts/check/check-backend-name-lookup-audit.py
+          python3 scripts/check/check-backend-typeid-first.py
+          python3 scripts/check/check-gc-hint-translation-validation.py
+          python3 scripts/check/check-corehir-body-boundary.py
+          python3 scripts/check/check-versioned-boundary-enforcement.py
 
       - name: Validate proof adapters
         run: |
           python3 -m unittest \
+            scripts.tests.test_boundary_registry \
             scripts.tests.test_proof_artifacts \
             scripts.tests.test_typed_corehir_artifacts \
             scripts.tests.test_typed_corehir_convert \
-            scripts.tests.test_source_contract_profile \
-            scripts.tests.test_source_proof_binding \
             scripts.tests.test_verified_core_typed \
             scripts.tests.test_smtlib_typed_v1 \
+            scripts.tests.test_typed_verified_core_receipt \
+            scripts.tests.test_source_contract_profile \
+            scripts.tests.test_source_proof_binding \
+            scripts.tests.test_proof_required_release_gate \
             scripts.tests.test_solver_result \
+            scripts.tests.test_solver_trust_boundary_receipt \
             scripts.tests.test_solver_driver
 
       - name: Install Wasmtime and Z3
@@ -48,6 +62,26 @@ jobs:
           cargo build --release --quiet
           cargo test --lib --no-run --quiet
         working-directory: tools/host-linker
+
+      - name: Generate and validate boundary evidence
+        run: |
+          python3 scripts/check/check-boundary-registry.py \
+            --registry release/boundary-registry.json \
+            --repository "$GITHUB_REPOSITORY" \
+            --receipt-output .build/proof/boundary-registry-validation.json
+          python3 scripts/check/check-boundary-registry-receipt.py \
+            --registry release/boundary-registry.json \
+            --receipt .build/proof/boundary-registry-validation.json \
+            --repository "$GITHUB_REPOSITORY"
+          python3 scripts/gen/write-backend-typeid-layout-receipt.py
+          python3 scripts/gen/write-mir-opt-translation-registry.py
+          python3 scripts/gen/write-corehir-body-boundary-receipt.py
+          python3 scripts/gen/write-typed-verified-core-boundary-receipt.py
+          python3 scripts/check/check-typed-verified-core-boundary-receipt.py \
+            .build/proof/typed-verified-core-boundary.json
+          python3 scripts/gen/write-solver-trust-boundary-receipt.py
+          python3 scripts/check/check-solver-trust-boundary-receipt.py \
+            .build/proof/solver-trust-boundary.json
 
       - name: Build current selfhost stage 2 runtime
         run: |
@@ -66,13 +100,11 @@ jobs:
           PY
           test -s .build/selfhost/arukellt-s2-runtime.wasm
 
-      - name: Emit and validate typed source contracts
+      - name: Emit and convert typed source contracts
         env:
           ARUKELLT_SELFHOST_WASM: .build/selfhost/arukellt-s2-runtime.wasm
-        run: python3 scripts/check/check-typed-contract-emission.py
-
-      - name: Convert compiler artifact into typed proof VCs
         run: |
+          python3 scripts/check/check-typed-contract-emission.py
           python3 scripts/gen/convert-typed-corehir.py \
             --input .build/typed-contract-proof/typed-corehir.json \
             --output .build/typed-contract-proof/verified-core-machine.json
@@ -86,6 +118,19 @@ jobs:
           python3 scripts/gen/write-smt-vcs.py \
             --subject .build/typed-contract-proof/verified-core.json \
             --output .build/typed-contract-proof/verified-core-vcs.smt2
+
+      - name: Bind proof invocation and payload
+        run: |
+          cp .build/selfhost/arukellt-s2-runtime.wasm \
+            .build/typed-contract-proof/arukellt-s2-runtime.wasm
+          python3 scripts/gen/write-release-provenance.py \
+            --repository "$GITHUB_REPOSITORY" --commit "$GITHUB_SHA" \
+            --ref-type pull_request --ref-name "$GITHUB_REF_NAME" \
+            --workflow "$GITHUB_WORKFLOW" --run-id "$GITHUB_RUN_ID" \
+            --output .build/typed-contract-proof/proof-provenance.json
+          python3 scripts/gen/write-release-payload-manifest.py \
+            --payload arukellt-wasm=.build/typed-contract-proof/arukellt-s2-runtime.wasm \
+            --output .build/typed-contract-proof/proof-payload-manifest.json
           python3 scripts/gen/write-source-proof-binding.py \
             --source tests/verified-core/contract_identity.ark \
             --producer-executable .build/selfhost/arukellt-s2-runtime.wasm \
@@ -93,82 +138,25 @@ jobs:
             --verified-core-machine .build/typed-contract-proof/verified-core-machine.json \
             --verified-core-normalized .build/typed-contract-proof/verified-core.json \
             --solver-input .build/typed-contract-proof/verified-core-vcs.smt2 \
+            --boundary-registry release/boundary-registry.json \
+            --boundary-registry-validation-receipt .build/proof/boundary-registry-validation.json \
+            --backend-typeid-layout-receipt .build/proof/backend-typeid-layout.json \
+            --optimizer-translation-registry .build/proof/mir-opt-translation-registry.json \
+            --corehir-body-boundary-receipt .build/proof/corehir-body-boundary.json \
+            --release-provenance .build/typed-contract-proof/proof-provenance.json \
+            --release-payload-manifest .build/typed-contract-proof/proof-payload-manifest.json \
             --output .build/typed-contract-proof/source-proof-binding.json
 
-      - name: Build hash-bound typed proof toolchain
+      - name: Build hash-bound proof toolchain
         run: |
-          mkdir -p .build/typed-contract-toolchain
-          cp .build/selfhost/arukellt-s2-runtime.wasm .build/typed-contract-toolchain/arukellt-s2-runtime.wasm
-          cp "$(command -v z3)" .build/typed-contract-toolchain/z3
-          cp .build/typed-contract-proof/source-proof-binding.json .build/typed-contract-toolchain/source-proof-binding.json
-          cp scripts/proof/common.py .build/typed-contract-toolchain/common.py
-          cp scripts/proof/source_proof_binding.py .build/typed-contract-toolchain/source_proof_binding.py
-          cp scripts/proof/typed_corehir.py .build/typed-contract-toolchain/typed_corehir.py
-          cp scripts/proof/typed_corehir_impl.py .build/typed-contract-toolchain/typed_corehir_impl.py
-          cp scripts/proof/typed_corehir_typed_convert.py .build/typed-contract-toolchain/typed_corehir_typed_convert.py
-          cp scripts/proof/typed_corehir_convert.py .build/typed-contract-toolchain/typed_corehir_convert.py
-          cp scripts/proof/normalize_source_contract_profile.py .build/typed-contract-toolchain/normalize_source_contract_profile.py
-          cp scripts/proof/verified_core.py .build/typed-contract-toolchain/verified_core.py
-          cp scripts/proof/verified_core_typed.py .build/typed-contract-toolchain/verified_core_typed.py
-          cp scripts/proof/smtlib_typed_v1.py .build/typed-contract-toolchain/smtlib_typed_v1.py
-          cp scripts/proof/smtlib_v1.py .build/typed-contract-toolchain/smtlib_v1.py
-          python3 - <<'PY'
-          import json
-          import subprocess
-          from pathlib import Path
-          version = subprocess.check_output(["z3", "--version"], text=True).strip()
-          components = [
-              ("arukellt-source-proof-binding-v1", "source-artifact-binding", "1", "source-proof-binding.json"),
-              ("arukellt-source-proof-binding-validator-v1", "source-artifact-binding-validator", "1", "source_proof_binding.py"),
-              ("arukellt-typed-corehir-validator-v1", "typed-corehir-validator", "1", "typed_corehir.py"),
-              ("arukellt-typed-corehir-validator-impl-v1", "typed-corehir-validator-implementation", "1", "typed_corehir_impl.py"),
-              ("arukellt-typed-corehir-to-verified-core-v2", "typed-proof-boundary", "2", "typed_corehir_typed_convert.py"),
-              ("arukellt-typed-corehir-converter-implementation-v1", "typed-proof-boundary-implementation", "1", "typed_corehir_convert.py"),
-              ("arukellt-source-contract-profile-normalizer-v1", "semantic-profile-normalizer", "1", "normalize_source_contract_profile.py"),
-              ("arukellt-verified-core-structural-validator-v1", "artifact-validator", "1", "verified_core.py"),
-              ("arukellt-verified-core-semantic-validator-v1", "typed-artifact-validator", "1", "verified_core_typed.py"),
-              ("arukellt-typed-verified-core-smt-adapter-v1", "typed-smt-adapter", "1", "smtlib_typed_v1.py"),
-              ("arukellt-smt-renderer-v1", "smt-renderer-implementation", "1", "smtlib_v1.py"),
-          ]
-          document = {
-              "schema": "arukellt-proof-toolchain",
-              "schema_version": 1,
-              "producer": {
-                  "name": "arukellt-selfhost-typed-contract-emitter",
-                  "version": "current-s2-runtime",
-                  "executable": "arukellt-s2-runtime.wasm",
-                  "arguments": ["compile", "tests/verified-core/contract_identity.ark", "--emit", "typed-corehir"],
-              },
-              "translator": {
-                  "name": "arukellt-typed-verified-core-smtlib",
-                  "version": "1",
-                  "executable": "smtlib_typed_v1.py",
-              },
-              "solver": {
-                  "name": "z3",
-                  "version": version,
-                  "executable": "z3",
-                  "arguments": ["-in", "-smt2"],
-              },
-              "semantic_profile": {
-                  "integer_model": "mathematical",
-                  "overflow": "checked",
-                  "floating_point": "unsupported",
-                  "memory": "pure-values",
-              },
-              "assumptions": [],
-              "trusted_components": [
-                  {"name": name, "role": role, "version": version, "artifact": artifact}
-                  for name, role, version, artifact in components
-              ],
-              "limits": {"timeout_ms": 10000, "memory_bytes": 1073741824},
-          }
-          Path(".build/typed-contract-toolchain/toolchain.json").write_text(
-              json.dumps(document, indent=2) + "\n", encoding="utf-8"
-          )
-          PY
+          python3 scripts/gen/prepare-proof-release-toolchain.py \
+            --runtime .build/selfhost/arukellt-s2-runtime.wasm \
+            --source-binding .build/typed-contract-proof/source-proof-binding.json \
+            --output-dir .build/typed-contract-toolchain \
+            --toolchain-output .build/typed-contract-toolchain/toolchain.json \
+            --z3 "$(command -v z3)"
 
-      - name: Prove compiler-emitted contracts with Z3
+      - name: Prove and independently validate SolverResult
         run: |
           python3 scripts/run/run-proof-solver.py \
             --subject .build/typed-contract-proof/verified-core.json \
@@ -187,26 +175,29 @@ jobs:
             --trust-manifest .build/typed-contract-proof/trust-manifest.json \
             --proof-receipt .build/typed-contract-proof/proof-receipt.json
 
-      - name: Verify source-to-result bindings
+      - name: Verify source binding
         run: |
           python3 - <<'PY'
-          import json
-          import sys
+          import json, sys
           from pathlib import Path
           sys.path.insert(0, "scripts")
           from proof.source_proof_binding import validate_binding
           proof = Path(".build/typed-contract-proof")
-          validate_binding(
-              json.loads((proof / "source-proof-binding.json").read_text()),
-              {
-                  "source": Path("tests/verified-core/contract_identity.ark"),
-                  "producer_executable": Path(".build/selfhost/arukellt-s2-runtime.wasm"),
-                  "typed_corehir": proof / "typed-corehir.json",
-                  "verified_core_machine": proof / "verified-core-machine.json",
-                  "verified_core_normalized": proof / "verified-core.json",
-                  "solver_input": proof / "verified-core-vcs.smt2",
-              },
-          )
+          validate_binding(json.loads((proof / "source-proof-binding.json").read_text()), {
+              "source": Path("tests/verified-core/contract_identity.ark"),
+              "producer_executable": Path(".build/selfhost/arukellt-s2-runtime.wasm"),
+              "typed_corehir": proof / "typed-corehir.json",
+              "verified_core_machine": proof / "verified-core-machine.json",
+              "verified_core_normalized": proof / "verified-core.json",
+              "solver_input": proof / "verified-core-vcs.smt2",
+              "boundary_registry": Path("release/boundary-registry.json"),
+              "boundary_registry_validation_receipt": Path(".build/proof/boundary-registry-validation.json"),
+              "backend_typeid_layout_receipt": Path(".build/proof/backend-typeid-layout.json"),
+              "optimizer_translation_registry": Path(".build/proof/mir-opt-translation-registry.json"),
+              "corehir_body_boundary_receipt": Path(".build/proof/corehir-body-boundary.json"),
+              "release_provenance": proof / "proof-provenance.json",
+              "release_payload_manifest": proof / "proof-payload-manifest.json",
+          })
           result = json.loads((proof / "solver-result.json").read_text())
           if result["status"] != "proved":
               raise SystemExit(result)
@@ -220,4 +211,11 @@ jobs:
           path: |
             .build/typed-contract-proof
             .build/typed-contract-toolchain/toolchain.json
+            release/boundary-registry.json
+            .build/proof/boundary-registry-validation.json
+            .build/proof/backend-typeid-layout.json
+            .build/proof/mir-opt-translation-registry.json
+            .build/proof/corehir-body-boundary.json
+            .build/proof/typed-verified-core-boundary.json
+            .build/proof/solver-trust-boundary.json
           if-no-files-found: error

--- a/.github/workflows/typed-corehir-proof-pipeline.yml
+++ b/.github/workflows/typed-corehir-proof-pipeline.yml
@@ -2,7 +2,7 @@ name: TypedCoreHIR proof pipeline
 
 on:
   pull_request:
-    branches: [agent/verified-core-smtlib-vc, agent/z3-proof-run, agent/proof-solver-driver, agent/solver-bound-proof-receipts, agent/formal-verification-hard-gates, master]
+    branches: [agent/formal-verification-hard-gates, master]
   workflow_dispatch:
 
 concurrency:
@@ -10,36 +10,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  typed-corehir-proof-pipeline:
-    name: "TypedCoreHIR proof pipeline"
+  typed-corehir-proof:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Reject untyped or name-inferred conversion paths
-        run: python3 scripts/check/check-typed-verified-core-boundary.py
-
-      - name: Write and independently validate typed boundary receipt
+      - name: Enforce typed and solver boundaries
         run: |
+          python3 scripts/check/check-typed-verified-core-boundary.py
+          python3 scripts/check/check-solver-trust-manifest-boundary.py
           python3 scripts/gen/write-typed-verified-core-boundary-receipt.py
           python3 scripts/check/check-typed-verified-core-boundary-receipt.py \
             .build/proof/typed-verified-core-boundary.json
+          python3 scripts/gen/write-solver-trust-boundary-receipt.py
+          python3 scripts/check/check-solver-trust-boundary-receipt.py \
+            .build/proof/solver-trust-boundary.json
 
-      - name: Test conversion, semantic typing, and VC generation
+      - name: Run typed semantic negative tests
         run: |
           python3 -m unittest \
             scripts.tests.test_typed_corehir_convert \
             scripts.tests.test_verified_core_typed \
             scripts.tests.test_smtlib_typed_v1 \
             scripts.tests.test_typed_verified_core_receipt \
-            scripts.tests.test_smtlib_v1 \
-            scripts.tests.test_solver_receipts \
             scripts.tests.test_solver_result \
             scripts.tests.test_solver_driver
 
-      - name: Convert TypedCoreHIR into semantically typed VerifiedCore
+      - name: Convert and admit fixture
         run: |
-          mkdir -p .build/typed-corehir-proof
+          mkdir -p .build/typed-corehir-proof .build/typed-corehir-toolchain
           python3 scripts/gen/convert-typed-corehir.py \
             --input tests/proof/typed-corehir.json \
             --output .build/typed-corehir-proof/verified-core.json
@@ -49,23 +48,17 @@ jobs:
             --subject .build/typed-corehir-proof/verified-core.json \
             --output .build/typed-corehir-proof/verified-core-vcs.smt2
 
-      - name: Install Z3
+      - name: Build typed fixture toolchain
         run: |
-          sudo apt-get update
-          sudo apt-get install -y z3
-          z3 --version
-
-      - name: Build hash-bound typed proof toolchain
-        run: |
-          mkdir -p .build/typed-corehir-toolchain
-          cp "$(command -v z3)" .build/typed-corehir-toolchain/z3
+          chmod +x tests/proof/toolchain/fake_solver.py
           cp tests/proof/toolchain/producer.bin .build/typed-corehir-toolchain/producer.bin
-          cp scripts/proof/smtlib_typed_v1.py .build/typed-corehir-toolchain/smtlib_typed_v1.py
-          cp scripts/proof/smtlib_v1.py .build/typed-corehir-toolchain/smtlib_v1.py
+          cp tests/proof/toolchain/fake_solver.py .build/typed-corehir-toolchain/fake_solver.py
           cp scripts/proof/typed_corehir_typed_convert.py .build/typed-corehir-toolchain/typed_corehir_typed_convert.py
           cp scripts/proof/typed_corehir_convert.py .build/typed-corehir-toolchain/typed_corehir_convert.py
           cp scripts/proof/verified_core.py .build/typed-corehir-toolchain/verified_core.py
           cp scripts/proof/verified_core_typed.py .build/typed-corehir-toolchain/verified_core_typed.py
+          cp scripts/proof/smtlib_typed_v1.py .build/typed-corehir-toolchain/smtlib_typed_v1.py
+          cp scripts/proof/smtlib_v1.py .build/typed-corehir-toolchain/smtlib_v1.py
           cp scripts/proof/typed_verified_core_receipt.py .build/typed-corehir-toolchain/typed_verified_core_receipt.py
           cp scripts/check/check-typed-verified-core.py .build/typed-corehir-toolchain/check-typed-verified-core.py
           cp scripts/check/check-typed-verified-core-boundary.py .build/typed-corehir-toolchain/check-typed-verified-core-boundary.py
@@ -73,58 +66,37 @@ jobs:
           cp .build/proof/typed-verified-core-boundary.json .build/typed-corehir-toolchain/typed-verified-core-boundary.json
           python3 - <<'PY'
           import json
-          import subprocess
           from pathlib import Path
-
-          version = subprocess.check_output(["z3", "--version"], text=True).strip()
+          components = [
+              ("typed-proof-boundary", "2", "typed_corehir_typed_convert.py"),
+              ("typed-proof-boundary-implementation", "1", "typed_corehir_convert.py"),
+              ("artifact-validator", "1", "verified_core.py"),
+              ("typed-artifact-validator", "1", "verified_core_typed.py"),
+              ("typed-smt-adapter", "1", "smtlib_typed_v1.py"),
+              ("smt-renderer-implementation", "1", "smtlib_v1.py"),
+              ("typed-boundary-receipt-validator", "1", "typed_verified_core_receipt.py"),
+              ("typed-artifact-admission", "1", "check-typed-verified-core.py"),
+              ("typed-boundary-policy", "1", "check-typed-verified-core-boundary.py"),
+              ("typed-boundary-receipt-checker", "1", "check-typed-verified-core-boundary-receipt.py"),
+              ("typed-boundary-receipt", "1", "typed-verified-core-boundary.json"),
+          ]
           document = {
-              "schema": "arukellt-proof-toolchain",
-              "schema_version": 1,
-              "producer": {
-                  "name": "arukellt-typed-corehir-fixture",
-                  "version": "1",
-                  "executable": "producer.bin",
-              },
-              "translator": {
-                  "name": "arukellt-typed-verified-core-smtlib",
-                  "version": "1",
-                  "executable": "smtlib_typed_v1.py",
-              },
-              "solver": {
-                  "name": "z3",
-                  "version": version,
-                  "executable": "z3",
-                  "arguments": ["-in", "-smt2"],
-              },
-              "semantic_profile": {
-                  "integer_model": "mathematical",
-                  "overflow": "checked",
-                  "floating_point": "unsupported",
-                  "memory": "pure-values",
-              },
+              "schema": "arukellt-proof-toolchain", "schema_version": 1,
+              "producer": {"name": "typed-corehir-fixture", "version": "1", "executable": "producer.bin"},
+              "translator": {"name": "typed-verified-core-smt", "version": "1", "executable": "smtlib_typed_v1.py"},
+              "solver": {"name": "fake-z3", "version": "1", "executable": "fake_solver.py", "arguments": []},
+              "semantic_profile": {"integer_model": "mathematical", "overflow": "checked", "floating_point": "unsupported", "memory": "pure-values"},
               "assumptions": [],
               "trusted_components": [
-                  {"name": "arukellt-typed-corehir-to-verified-core-v2", "role": "typed-proof-boundary", "version": "2", "artifact": "typed_corehir_typed_convert.py"},
-                  {"name": "arukellt-typed-corehir-converter-implementation-v1", "role": "typed-proof-boundary-implementation", "version": "1", "artifact": "typed_corehir_convert.py"},
-                  {"name": "arukellt-verified-core-structural-validator-v1", "role": "artifact-validator", "version": "1", "artifact": "verified_core.py"},
-                  {"name": "arukellt-verified-core-semantic-validator-v1", "role": "typed-artifact-validator", "version": "1", "artifact": "verified_core_typed.py"},
-                  {"name": "arukellt-typed-verified-core-admission-cli-v1", "role": "typed-artifact-admission", "version": "1", "artifact": "check-typed-verified-core.py"},
-                  {"name": "arukellt-typed-verified-core-smt-adapter-v1", "role": "typed-smt-adapter", "version": "1", "artifact": "smtlib_typed_v1.py"},
-                  {"name": "arukellt-smt-renderer-v1", "role": "smt-renderer-implementation", "version": "1", "artifact": "smtlib_v1.py"},
-                  {"name": "arukellt-typed-verified-core-boundary-policy-v1", "role": "typed-boundary-policy", "version": "1", "artifact": "check-typed-verified-core-boundary.py"},
-                  {"name": "arukellt-typed-verified-core-receipt-validator-v1", "role": "typed-boundary-receipt-validator", "version": "1", "artifact": "typed_verified_core_receipt.py"},
-                  {"name": "arukellt-typed-verified-core-receipt-checker-v1", "role": "typed-boundary-receipt-checker", "version": "1", "artifact": "check-typed-verified-core-boundary-receipt.py"},
-                  {"name": "arukellt-typed-verified-core-boundary-receipt-v1", "role": "typed-boundary-receipt", "version": "1", "artifact": "typed-verified-core-boundary.json"},
+                  {"name": f"arukellt-{role}", "role": role, "version": version, "artifact": artifact}
+                  for role, version, artifact in components
               ],
               "limits": {"timeout_ms": 10000, "memory_bytes": 1073741824},
           }
-          Path(".build/typed-corehir-toolchain/toolchain.json").write_text(
-              json.dumps(document, indent=2) + "\n",
-              encoding="utf-8",
-          )
+          Path(".build/typed-corehir-toolchain/toolchain.json").write_text(json.dumps(document, indent=2) + "\n")
           PY
 
-      - name: Prove converted VerifiedCore with Z3
+      - name: Prove and validate SolverResult
         run: |
           python3 scripts/run/run-proof-solver.py \
             --subject .build/typed-corehir-proof/verified-core.json \
@@ -142,64 +114,14 @@ jobs:
             --solver-output .build/typed-corehir-proof/solver-output.txt \
             --trust-manifest .build/typed-corehir-proof/trust-manifest.json \
             --proof-receipt .build/typed-corehir-proof/proof-receipt.json
+          echo 'typed_semantics=bound-through-solver'
 
-      - name: Verify typed end-to-end bindings
-        run: |
-          python3 - <<'PY'
-          import hashlib
-          import json
-          import sys
-          from pathlib import Path
-
-          sys.path.insert(0, "scripts")
-          from proof.trust import validate_bound_proof
-          from proof.typed_verified_core_receipt import validate_boundary_receipt
-          from proof.verified_core_typed import validate_typed_document
-
-          root = Path(".build/typed-corehir-proof")
-          toolchain = Path(".build/typed-corehir-toolchain")
-          subject = root / "verified-core.json"
-          manifest_path = root / "trust-manifest.json"
-          receipt_path = root / "proof-receipt.json"
-          solver_output = root / "solver-output.txt"
-          boundary_receipt = Path(".build/proof/typed-verified-core-boundary.json")
-          validate_typed_document(json.loads(subject.read_text()))
-          validate_boundary_receipt(json.loads(boundary_receipt.read_text()), root=Path.cwd())
-          validate_bound_proof(subject, manifest_path, receipt_path, solver_output)
-
-          manifest = json.loads(manifest_path.read_text())
-          receipt = json.loads(receipt_path.read_text())
-          expected = {
-              "typed-proof-boundary": "typed_corehir_typed_convert.py",
-              "typed-proof-boundary-implementation": "typed_corehir_convert.py",
-              "artifact-validator": "verified_core.py",
-              "typed-artifact-validator": "verified_core_typed.py",
-              "typed-artifact-admission": "check-typed-verified-core.py",
-              "typed-smt-adapter": "smtlib_typed_v1.py",
-              "smt-renderer-implementation": "smtlib_v1.py",
-              "typed-boundary-policy": "check-typed-verified-core-boundary.py",
-              "typed-boundary-receipt-validator": "typed_verified_core_receipt.py",
-              "typed-boundary-receipt-checker": "check-typed-verified-core-boundary-receipt.py",
-              "typed-boundary-receipt": "typed-verified-core-boundary.json",
-          }
-          by_role = {item["role"]: item for item in manifest["trusted_components"]}
-          for role, filename in expected.items():
-              digest = hashlib.sha256((toolchain / filename).read_bytes()).hexdigest()
-              assert by_role[role]["artifact_sha256"] == digest
-          assert manifest["translator"]["executable_sha256"] == hashlib.sha256(
-              (toolchain / "smtlib_typed_v1.py").read_bytes()
-          ).hexdigest()
-          assert solver_output.read_text().strip() == "unsat"
-          assert receipt["status"] == "proved", receipt
-          print("typed-corehir-proof-pipeline: PASS: typed_semantics=bound-through-solver")
-          PY
-
-      - name: Upload end-to-end proof bundle
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: typed-corehir-proof-pipeline
           path: |
             .build/typed-corehir-proof
             .build/typed-corehir-toolchain/toolchain.json
             .build/proof/typed-verified-core-boundary.json
+            .build/proof/solver-trust-boundary.json
           if-no-files-found: error

--- a/.github/workflows/versioned-boundary-registry.yml
+++ b/.github/workflows/versioned-boundary-registry.yml
@@ -1,0 +1,49 @@
+name: Versioned major boundary registry
+
+on:
+  pull_request:
+    branches: [agent/proof-required-release-gate, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: versioned-boundary-registry-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-major-boundaries:
+    name: "Validate pinned artifact and validator boundaries"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run boundary registry negative tests
+        run: python3 -m unittest scripts.tests.test_boundary_registry scripts.tests.test_source_proof_binding
+
+      - name: Reject incomplete release integration
+        run: python3 scripts/check/check-versioned-boundary-enforcement.py
+
+      - name: Validate every pinned boundary and write receipt
+        run: |
+          python3 scripts/check/check-boundary-registry.py \
+            --registry release/boundary-registry.json \
+            --repository "$GITHUB_REPOSITORY" \
+            --receipt-output .build/proof/boundary-registry-validation.json
+
+      - name: Independently revalidate registry receipt
+        run: |
+          python3 scripts/check/check-boundary-registry-receipt.py \
+            --registry release/boundary-registry.json \
+            --receipt .build/proof/boundary-registry-validation.json \
+            --repository "$GITHUB_REPOSITORY"
+
+      - name: Upload boundary registry evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: versioned-boundary-registry
+          path: |
+            release/boundary-registry.json
+            .build/proof/boundary-registry-validation.json
+          if-no-files-found: error

--- a/.github/workflows/z3-proof-run.yml
+++ b/.github/workflows/z3-proof-run.yml
@@ -2,7 +2,7 @@ name: Z3 proof run
 
 on:
   pull_request:
-    branches: [agent/z3-proof-run, agent/proof-solver-driver, agent/solver-bound-proof-receipts, agent/formal-verification-hard-gates, master]
+    branches: [agent/formal-verification-hard-gates, master]
   workflow_dispatch:
 
 concurrency:
@@ -11,16 +11,20 @@ concurrency:
 
 jobs:
   z3-proof-run:
-    name: "Z3 proof run"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Test VerifiedCore SMT adapter and SolverResult
+      - name: Validate solver trust boundary
         run: |
+          python3 scripts/check/check-solver-trust-manifest-boundary.py
+          python3 scripts/gen/write-solver-trust-boundary-receipt.py
+          python3 scripts/check/check-solver-trust-boundary-receipt.py \
+            .build/proof/solver-trust-boundary.json
           python3 -m unittest \
-            scripts.tests.test_smtlib_v1 \
-            scripts.tests.test_solver_result
+            scripts.tests.test_smtlib_typed_v1 \
+            scripts.tests.test_solver_result \
+            scripts.tests.test_solver_driver
 
       - name: Install Z3
         run: |
@@ -28,70 +32,44 @@ jobs:
           sudo apt-get install -y z3
           z3 --version
 
-      - name: Generate verification conditions from VerifiedCore
+      - name: Generate typed verification conditions
         run: |
-          mkdir -p .build/z3-proof
+          mkdir -p .build/z3-proof .build/z3-toolchain
+          python3 scripts/check/check-typed-verified-core.py tests/proof/verified-core.json
           python3 scripts/gen/write-smt-vcs.py \
             --subject tests/proof/verified-core.json \
             --output .build/z3-proof/verified-core-vcs.smt2
-          grep -q '(check-sat)' .build/z3-proof/verified-core-vcs.smt2
 
-      - name: Build hash-bound toolchain bundle
+      - name: Build hash-bound Z3 toolchain
         run: |
-          mkdir -p .build/z3-toolchain
           cp "$(command -v z3)" .build/z3-toolchain/z3
           cp tests/proof/toolchain/producer.bin .build/z3-toolchain/producer.bin
+          cp scripts/proof/smtlib_typed_v1.py .build/z3-toolchain/smtlib_typed_v1.py
           cp scripts/proof/smtlib_v1.py .build/z3-toolchain/smtlib_v1.py
-          cp tests/proof/toolchain/trusted-component.txt .build/z3-toolchain/trusted-component.txt
+          cp scripts/proof/verified_core.py .build/z3-toolchain/verified_core.py
+          cp scripts/proof/verified_core_typed.py .build/z3-toolchain/verified_core_typed.py
           python3 - <<'PY'
-          import json
-          import subprocess
+          import json, subprocess
           from pathlib import Path
-
-          version = subprocess.check_output(["z3", "--version"], text=True).strip()
           document = {
-              "schema": "arukellt-proof-toolchain",
-              "schema_version": 1,
-              "producer": {
-                  "name": "arukellt",
-                  "version": "fixture-subject-producer",
-                  "executable": "producer.bin",
-              },
-              "translator": {
-                  "name": "arukellt-verified-core-smtlib",
-                  "version": "1",
-                  "executable": "smtlib_v1.py",
-              },
-              "solver": {
-                  "name": "z3",
-                  "version": version,
-                  "executable": "z3",
-                  "arguments": ["-in", "-smt2"],
-              },
-              "semantic_profile": {
-                  "integer_model": "mathematical",
-                  "overflow": "checked",
-                  "floating_point": "unsupported",
-                  "memory": "pure-values",
-              },
+              "schema": "arukellt-proof-toolchain", "schema_version": 1,
+              "producer": {"name": "verified-core-fixture", "version": "1", "executable": "producer.bin"},
+              "translator": {"name": "typed-verified-core-smt", "version": "1", "executable": "smtlib_typed_v1.py"},
+              "solver": {"name": "z3", "version": subprocess.check_output(["z3", "--version"], text=True).strip(), "executable": "z3", "arguments": ["-in", "-smt2"]},
+              "semantic_profile": {"integer_model": "mathematical", "overflow": "checked", "floating_point": "unsupported", "memory": "pure-values"},
               "assumptions": [],
               "trusted_components": [
-                  {
-                      "name": "arukellt-verified-core-v1",
-                      "role": "artifact-validator",
-                      "version": "1",
-                      "artifact": "trusted-component.txt",
-                  }
+                  {"name": "arukellt-verified-core", "role": "artifact-validator", "version": "1", "artifact": "verified_core.py"},
+                  {"name": "arukellt-verified-core-typed", "role": "typed-artifact-validator", "version": "1", "artifact": "verified_core_typed.py"},
+                  {"name": "arukellt-typed-smt", "role": "typed-smt-adapter", "version": "1", "artifact": "smtlib_typed_v1.py"},
+                  {"name": "arukellt-smt-renderer", "role": "smt-renderer-implementation", "version": "1", "artifact": "smtlib_v1.py"},
               ],
               "limits": {"timeout_ms": 10000, "memory_bytes": 1073741824},
           }
-          Path(".build/z3-toolchain/toolchain.json").write_text(
-              json.dumps(document, indent=2) + "\n",
-              encoding="utf-8",
-          )
+          Path(".build/z3-toolchain/toolchain.json").write_text(json.dumps(document, indent=2) + "\n")
           PY
 
-      - name: Prove generated contracts with Z3
+      - name: Prove and independently validate SolverResult
         run: |
           python3 scripts/run/run-proof-solver.py \
             --subject tests/proof/verified-core.json \
@@ -110,40 +88,11 @@ jobs:
             --trust-manifest .build/z3-proof/trust-manifest.json \
             --proof-receipt .build/z3-proof/proof-receipt.json
 
-      - name: Verify translator, solver identity, and bindings
-        run: |
-          python3 - <<'PY'
-          import hashlib
-          import json
-          import sys
-          from pathlib import Path
-
-          sys.path.insert(0, "scripts")
-          from proof.trust import validate_bound_proof
-
-          subject = Path("tests/proof/verified-core.json")
-          output = Path(".build/z3-proof/solver-output.txt")
-          manifest_path = Path(".build/z3-proof/trust-manifest.json")
-          receipt_path = Path(".build/z3-proof/proof-receipt.json")
-          validate_bound_proof(subject, manifest_path, receipt_path, output)
-
-          manifest = json.loads(manifest_path.read_text())
-          receipt = json.loads(receipt_path.read_text())
-          z3_path = Path(".build/z3-toolchain/z3")
-          translator_path = Path(".build/z3-toolchain/smtlib_v1.py")
-          assert manifest["solver"]["name"] == "z3"
-          assert manifest["solver"]["executable_sha256"] == hashlib.sha256(z3_path.read_bytes()).hexdigest()
-          assert manifest["translator"]["executable_sha256"] == hashlib.sha256(translator_path.read_bytes()).hexdigest()
-          assert output.read_text().strip() == "unsat"
-          assert receipt["status"] == "proved", receipt
-          print("verified-core-z3-proof-run: PASS")
-          PY
-
-      - name: Upload generated proof artifacts
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: verified-core-z3-proof-run
           path: |
-            .build/z3-toolchain/toolchain.json
             .build/z3-proof
+            .build/z3-toolchain/toolchain.json
+            .build/proof/solver-trust-boundary.json
           if-no-files-found: error

--- a/release/boundary-registry.json
+++ b/release/boundary-registry.json
@@ -1,0 +1,269 @@
+{
+  "schema": "arukellt-boundary-registry",
+  "schema_version": 1,
+  "status": "enforced",
+  "repository": "wogikaze/arukellt",
+  "required_boundaries": [
+    "typed-corehir",
+    "corehir-body",
+    "verified-core",
+    "mir-optimizer",
+    "backend-layout",
+    "solver-result",
+    "release-authorization"
+  ],
+  "boundaries": [
+    {
+      "id": "typed-corehir",
+      "artifact": {
+        "schema": "arukellt-typed-corehir",
+        "schema_version": 1,
+        "kind": "serialized-json"
+      },
+      "producer": {
+        "commit": "c6b502c12f76d3f83a7c46806efd490cafba4449",
+        "path": "src/compiler/driver/typed_corehir_render.ark",
+        "required_tokens": ["render_typed_corehir", "arukellt-typed-corehir"]
+      },
+      "validator": {
+        "commit": "c6b502c12f76d3f83a7c46806efd490cafba4449",
+        "path": "scripts/proof/typed_corehir.py",
+        "required_tokens": ["Independent public validator", "validate_document"]
+      },
+      "consumers": [
+        {
+          "commit": "8f2623316d92eba4ae635ee9948b50e209b6e07e",
+          "path": "scripts/proof/typed_corehir_typed_convert.py",
+          "required_tokens": ["convert_typed_document", "explicit logical type"]
+        }
+      ],
+      "evidence": {
+        "commit": "c6b502c12f76d3f83a7c46806efd490cafba4449",
+        "path": "scripts/check/check-typed-corehir-emission.py",
+        "required_tokens": ["typed-corehir"]
+      },
+      "workflow": {
+        "commit": "c6b502c12f76d3f83a7c46806efd490cafba4449",
+        "path": ".github/workflows/verified-core-emitter.yml",
+        "required_tokens": ["typed-corehir"]
+      },
+      "failure_action": "reject artifact before MIR or proof consumption"
+    },
+    {
+      "id": "corehir-body",
+      "artifact": {
+        "schema": "arukellt-corehir-body-artifact",
+        "schema_version": 1,
+        "kind": "in-memory-snapshot"
+      },
+      "producer": {
+        "commit": "8972fb5d377c8d4f6dca987c51c3b20fad352f00",
+        "path": "src/compiler/corehir/body_builder.ark",
+        "required_tokens": ["corehir_body_builder_finish", "body_validator"]
+      },
+      "validator": {
+        "commit": "8972fb5d377c8d4f6dca987c51c3b20fad352f00",
+        "path": "src/compiler/corehir/body_validator.ark",
+        "required_tokens": ["corehir_body_artifact_valid", "schema_version"]
+      },
+      "consumers": [
+        {
+          "commit": "8972fb5d377c8d4f6dca987c51c3b20fad352f00",
+          "path": "src/compiler/corehir/mir_body_source.ark",
+          "required_tokens": ["CoreHirMirBodySource", "children"]
+        }
+      ],
+      "evidence": {
+        "commit": "8972fb5d377c8d4f6dca987c51c3b20fad352f00",
+        "path": "scripts/gen/write-corehir-body-boundary-receipt.py",
+        "required_tokens": ["arukellt-corehir-body-boundary-receipt", "detached deep snapshot"]
+      },
+      "workflow": {
+        "commit": "8972fb5d377c8d4f6dca987c51c3b20fad352f00",
+        "path": ".github/workflows/corehir-body-boundary.yml",
+        "required_tokens": ["corehir-body-boundary"]
+      },
+      "failure_action": "compiler ICE before MIR lowering"
+    },
+    {
+      "id": "verified-core",
+      "artifact": {
+        "schema": "arukellt-verified-core",
+        "schema_version": 1,
+        "kind": "serialized-json"
+      },
+      "producer": {
+        "commit": "8f2623316d92eba4ae635ee9948b50e209b6e07e",
+        "path": "scripts/proof/typed_corehir_typed_convert.py",
+        "required_tokens": ["convert_typed_document", "validate_typed_document"]
+      },
+      "validator": {
+        "commit": "8f2623316d92eba4ae635ee9948b50e209b6e07e",
+        "path": "scripts/proof/verified_core_typed.py",
+        "required_tokens": ["Independent semantic type validation", "validate_typed_document"]
+      },
+      "consumers": [
+        {
+          "commit": "8f2623316d92eba4ae635ee9948b50e209b6e07e",
+          "path": "scripts/proof/smtlib_typed_v1.py",
+          "required_tokens": ["validate_typed_document", "generate_smtlib"]
+        }
+      ],
+      "evidence": {
+        "commit": "8f2623316d92eba4ae635ee9948b50e209b6e07e",
+        "path": "scripts/gen/write-typed-verified-core-boundary-receipt.py",
+        "required_tokens": ["arukellt-typed-verified-core-boundary", "semantic-admission-before-SMT"]
+      },
+      "workflow": {
+        "commit": "8f2623316d92eba4ae635ee9948b50e209b6e07e",
+        "path": ".github/workflows/typed-corehir-proof-pipeline.yml",
+        "required_tokens": ["typed_semantics=bound-through-solver"]
+      },
+      "failure_action": "reject before SMT generation"
+    },
+    {
+      "id": "mir-optimizer",
+      "artifact": {
+        "schema": "arukellt-mir-opt-translation-validator-registry",
+        "schema_version": 3,
+        "kind": "serialized-json"
+      },
+      "producer": {
+        "commit": "8682f784c10b7bd8cea5ebcebe47735bd67f9815",
+        "path": "scripts/gen/write-mir-opt-translation-registry.py",
+        "required_tokens": ["arukellt-mir-opt-translation-validator-registry", "ENABLED_PASSES"]
+      },
+      "validator": {
+        "commit": "8682f784c10b7bd8cea5ebcebe47735bd67f9815",
+        "path": "scripts/check/check-gc-hint-translation-validation.py",
+        "required_tokens": ["stdlib_resolve_normal_calls", "translation"]
+      },
+      "consumers": [
+        {
+          "commit": "8682f784c10b7bd8cea5ebcebe47735bd67f9815",
+          "path": "src/compiler/mir_opt/orchestrate.ark",
+          "required_tokens": ["stdlib_resolve_validated", "gc_hint"]
+        }
+      ],
+      "evidence": {
+        "commit": "8682f784c10b7bd8cea5ebcebe47735bd67f9815",
+        "path": ".github/workflows/gc-hint-translation-validation.yml",
+        "required_tokens": ["mir-opt-translation-registry.json"]
+      },
+      "workflow": {
+        "commit": "8682f784c10b7bd8cea5ebcebe47735bd67f9815",
+        "path": ".github/workflows/gc-hint-translation-validation.yml",
+        "required_tokens": ["MIR optimizer translation validation"]
+      },
+      "failure_action": "restore original MIR candidate"
+    },
+    {
+      "id": "backend-layout",
+      "artifact": {
+        "schema": "arukellt-mir-gc-layout-plan",
+        "schema_version": 1,
+        "kind": "typed-mir-snapshot"
+      },
+      "producer": {
+        "commit": "75a2aec77f9230921552d53e4a2de7bc7359c378",
+        "path": "src/compiler/mir/lower/gc_layout_plan_build.ark",
+        "required_tokens": ["gc_layout_plan", "TypeId"]
+      },
+      "validator": {
+        "commit": "75a2aec77f9230921552d53e4a2de7bc7359c378",
+        "path": "src/compiler/mir/gc_layout_plan_validator.ark",
+        "required_tokens": ["gc_layout_plan", "schema_version"]
+      },
+      "consumers": [
+        {
+          "commit": "75a2aec77f9230921552d53e4a2de7bc7359c378",
+          "path": "src/compiler/wasm/gc_layout_table_build.ark",
+          "required_tokens": ["gc_layout_plan", "type_id"]
+        }
+      ],
+      "evidence": {
+        "commit": "75a2aec77f9230921552d53e4a2de7bc7359c378",
+        "path": "scripts/gen/write-backend-typeid-layout-receipt.py",
+        "required_tokens": ["arukellt-backend-typeid-layout-boundary", "backend_layout_offset_inference"]
+      },
+      "workflow": {
+        "commit": "75a2aec77f9230921552d53e4a2de7bc7359c378",
+        "path": ".github/workflows/backend-name-lookup-audit.yml",
+        "required_tokens": ["backend-typeid-layout"]
+      },
+      "failure_action": "compiler ICE before Wasm emission"
+    },
+    {
+      "id": "solver-result",
+      "artifact": {
+        "schema": "arukellt-solver-result",
+        "schema_version": 1,
+        "kind": "serialized-json"
+      },
+      "producer": {
+        "commit": "30473e84b366f590c936ece90679c000387b7462",
+        "path": "scripts/proof/solver_driver.py",
+        "required_tokens": ["create_solver_result", "solver_result_path"]
+      },
+      "validator": {
+        "commit": "30473e84b366f590c936ece90679c000387b7462",
+        "path": "scripts/proof/solver_result.py",
+        "required_tokens": ["arukellt-solver-result", "validate_solver_result"]
+      },
+      "consumers": [
+        {
+          "commit": "30473e84b366f590c936ece90679c000387b7462",
+          "path": "scripts/check/check-solver-result.py",
+          "required_tokens": ["validate_solver_result_file"]
+        }
+      ],
+      "evidence": {
+        "commit": "30473e84b366f590c936ece90679c000387b7462",
+        "path": "scripts/proof/solver_trust_boundary_receipt.py",
+        "required_tokens": ["arukellt-solver-trust-boundary", "embedded-trust-manifest"]
+      },
+      "workflow": {
+        "commit": "30473e84b366f590c936ece90679c000387b7462",
+        "path": ".github/workflows/proof-solver-driver.yml",
+        "required_tokens": ["solver-result.json"]
+      },
+      "failure_action": "do not emit a valid solver result"
+    },
+    {
+      "id": "release-authorization",
+      "artifact": {
+        "schema": "arukellt-proof-release-authorization",
+        "schema_version": 1,
+        "kind": "serialized-json"
+      },
+      "producer": {
+        "commit": "f166fd011ba04d23a71488c408ae6b546fcb0f94",
+        "path": "scripts/check/check-proof-required-release.py",
+        "required_tokens": ["create_release_authorization", "write_release_authorization"]
+      },
+      "validator": {
+        "commit": "f166fd011ba04d23a71488c408ae6b546fcb0f94",
+        "path": "scripts/check/check-release-authorization.py",
+        "required_tokens": ["validate_bound_release_authorization", "release authorization"]
+      },
+      "consumers": [
+        {
+          "commit": "f166fd011ba04d23a71488c408ae6b546fcb0f94",
+          "path": ".github/workflows/proof-required-release.yml",
+          "required_tokens": ["Verify publisher-side authorization"]
+        }
+      ],
+      "evidence": {
+        "commit": "f166fd011ba04d23a71488c408ae6b546fcb0f94",
+        "path": "scripts/gen/write-proof-release-enforcement-receipt.py",
+        "required_tokens": ["arukellt-proof-release-enforcement", "authorization_required"]
+      },
+      "workflow": {
+        "commit": "f166fd011ba04d23a71488c408ae6b546fcb0f94",
+        "path": ".github/workflows/proof-required-release.yml",
+        "required_tokens": ["Proof required release authorization"]
+      },
+      "failure_action": "publisher receives no authorization"
+    }
+  ]
+}

--- a/release/proof-policy.json
+++ b/release/proof-policy.json
@@ -3,7 +3,7 @@
   "schema_version": 1,
   "mode": "proof-optional",
   "hard_gates": {
-    "versioned_boundary_artifacts": false,
+    "versioned_boundary_artifacts": true,
     "explicit_backend_type_abi_layout": true,
     "typed_verified_core_emission": true,
     "optimizer_translation_validation": true,

--- a/scripts/check/check-boundary-registry-receipt.py
+++ b/scripts/check/check-boundary-registry-receipt.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Independently revalidate a major-boundary registry receipt."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.boundary_registry import BoundaryRegistryError, GitHubRawSource, load_registry  # noqa: E402
+from proof.boundary_registry_receipt import (  # noqa: E402
+    BoundaryRegistryReceiptError,
+    load_validation_receipt,
+    validate_validation_receipt,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=ROOT / "release" / "boundary-registry.json",
+    )
+    parser.add_argument(
+        "--receipt",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "boundary-registry-validation.json",
+    )
+    parser.add_argument("--repository")
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    args = parser.parse_args()
+
+    registry_path = args.registry.resolve()
+    registry = load_registry(registry_path)
+    if args.repository is not None and args.repository != registry["repository"]:
+        raise BoundaryRegistryReceiptError(
+            f"repository mismatch: registry={registry['repository']} requested={args.repository}"
+        )
+    receipt = load_validation_receipt(args.receipt.resolve())
+    validated = validate_validation_receipt(
+        receipt,
+        registry_path=registry_path,
+        source=GitHubRawSource(timeout_seconds=args.timeout_seconds),
+    )
+    print(
+        "boundary-registry-receipt: PASS: "
+        f"boundaries={validated['boundary_count']} files={len(validated['files'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, BoundaryRegistryError, BoundaryRegistryReceiptError) as exc:
+        print(f"boundary-registry-receipt: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/check/check-boundary-registry.py
+++ b/scripts/check/check-boundary-registry.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Validate every pinned major boundary and write a versioned receipt."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.boundary_registry import (  # noqa: E402
+    BoundaryRegistryError,
+    GitHubRawSource,
+    load_registry,
+)
+from proof.boundary_registry_receipt import (  # noqa: E402
+    BoundaryRegistryReceiptError,
+    create_validation_receipt,
+    validate_validation_receipt,
+    write_validation_receipt,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=ROOT / "release" / "boundary-registry.json",
+    )
+    parser.add_argument("--repository")
+    parser.add_argument(
+        "--receipt-output",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "boundary-registry-validation.json",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    args = parser.parse_args()
+
+    registry_path = args.registry.resolve()
+    registry = load_registry(registry_path)
+    if args.repository is not None and args.repository != registry["repository"]:
+        raise BoundaryRegistryError(
+            f"repository mismatch: registry={registry['repository']} requested={args.repository}"
+        )
+    source = GitHubRawSource(timeout_seconds=args.timeout_seconds)
+    receipt = create_validation_receipt(registry_path, source)
+    output = args.receipt_output.resolve()
+    write_validation_receipt(receipt, output)
+    validate_validation_receipt(receipt, registry_path=registry_path)
+    print(
+        "boundary-registry: PASS: "
+        f"boundaries={receipt['boundary_count']} files={len(receipt['files'])} output={output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, BoundaryRegistryError, BoundaryRegistryReceiptError) as exc:
+        print(f"boundary-registry: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/check/check-proof-release-entrypoints.py
+++ b/scripts/check/check-proof-release-entrypoints.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Require every repository release/publish entrypoint to verify proof authorization."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+CANONICAL = WORKFLOWS / "proof-required-release.yml"
+CANONICAL_SCRIPT = ROOT / "scripts" / "run" / "proof-required-release.sh"
+PUBLISH_AUTHORIZATION_COMMAND = "python3 scripts/check/check-release-authorization.py"
+
+PUBLISH_TOKENS = (
+    "gh release create",
+    "softprops/action-gh-release",
+    "actions/create-release",
+    "ncipollo/release-action",
+    "cargo publish",
+    "npm publish",
+    "pnpm publish",
+    "yarn npm publish",
+    "twine upload",
+    "docker push",
+    "docker/build-push-action",
+)
+
+
+def main() -> int:
+    if not CANONICAL.is_file() or not CANONICAL_SCRIPT.is_file():
+        raise ValueError("canonical proof-required release entrypoint is missing")
+    canonical = CANONICAL.read_text(encoding="utf-8")
+    script = CANONICAL_SCRIPT.read_text(encoding="utf-8")
+    for token in (
+        "tags:",
+        '"v*"',
+        "permissions:",
+        "contents: read",
+        "bash scripts/run/proof-required-release.sh",
+        PUBLISH_AUTHORIZATION_COMMAND,
+        "release-authorization.json",
+    ):
+        if token not in canonical:
+            raise ValueError(f"canonical release workflow missing token: {token}")
+    if "contents: write" in canonical:
+        raise ValueError("proof authorization workflow must not publish or write releases")
+    for token in (
+        "check-proof-required-release.py",
+        "--authorization-output",
+        "--expected-repository",
+        "--expected-commit",
+        "--expected-tag",
+        "--release-payload-manifest",
+        "--release-payload \"arukellt-wasm=$PAYLOAD\"",
+        "test -s \"$AUTHORIZATION\"",
+    ):
+        if token not in script:
+            raise ValueError(f"canonical release command missing token: {token}")
+
+    violations: list[str] = []
+    for workflow in sorted((*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml"))):
+        text = workflow.read_text(encoding="utf-8")
+        publish_positions = [
+            (token, text.index(token))
+            for token in PUBLISH_TOKENS
+            if token in text
+        ]
+        if not publish_positions:
+            continue
+        relative = workflow.relative_to(ROOT)
+        if PUBLISH_AUTHORIZATION_COMMAND not in text:
+            violations.append(
+                f"{relative}: publish token(s) {[token for token, _ in publish_positions]} "
+                "without check-release-authorization.py"
+            )
+        else:
+            authorization_position = text.index(PUBLISH_AUTHORIZATION_COMMAND)
+            first_publish_position = min(position for _, position in publish_positions)
+            if authorization_position > first_publish_position:
+                violations.append(
+                    f"{relative}: proof authorization is checked after the first publish action"
+                )
+            required_arguments = (
+                "--authorization",
+                "--repository",
+                "--commit",
+                "--tag",
+                "--policy",
+                "--source-binding",
+                "--trust-manifest",
+                "--proof-receipt",
+                "--release-payload-manifest",
+                "--release-payload",
+            )
+            prefix = text[authorization_position:first_publish_position]
+            missing = [argument for argument in required_arguments if argument not in prefix]
+            if missing:
+                violations.append(
+                    f"{relative}: authorization check before publish is missing argument(s): {missing}"
+                )
+        if "continue-on-error: true" in text:
+            violations.append(
+                f"{relative}: publish workflow allows continue-on-error"
+            )
+    if violations:
+        raise ValueError("\n".join(violations))
+    print(
+        "proof-release-entrypoints: PASS: "
+        "canonical authorization workflow present; every publisher verifies first"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"proof-release-entrypoints: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/check/check-proof-required-release.py
+++ b/scripts/check/check-proof-required-release.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Validate the complete source-to-ProofReceipt release chain."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.common import ValidationError  # noqa: E402
+from proof.release_authorization import (  # noqa: E402
+    ReleaseAuthorizationError,
+    create_release_authorization,
+    write_release_authorization,
+)
+from proof.release_gate import (  # noqa: E402
+    ProofRequiredReleaseError,
+    primary_release_artifact_paths,
+    validate_proof_required_release,
+)
+from proof.release_payload import ReleasePayloadError  # noqa: E402
+from proof.release_provenance import ReleaseProvenanceError  # noqa: E402
+from proof.source_proof_binding import SourceProofBindingError  # noqa: E402
+
+
+def parse_payload(raw: str) -> tuple[str, Path]:
+    name, separator, path = raw.partition("=")
+    if not separator or not name or not path:
+        raise ValueError("--release-payload must be NAME=PATH")
+    return name, Path(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("policy", type=Path)
+    parser.add_argument("--source-binding", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--producer-executable", type=Path, required=True)
+    parser.add_argument("--typed-corehir", type=Path, required=True)
+    parser.add_argument("--verified-core-machine", type=Path, required=True)
+    parser.add_argument("--verified-core-normalized", type=Path, required=True)
+    parser.add_argument("--solver-input", type=Path, required=True)
+    parser.add_argument(
+        "--boundary-registry",
+        type=Path,
+        default=ROOT / "release" / "boundary-registry.json",
+    )
+    parser.add_argument(
+        "--boundary-registry-validation-receipt",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "boundary-registry-validation.json",
+    )
+    parser.add_argument(
+        "--backend-typeid-layout-receipt",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "backend-typeid-layout.json",
+    )
+    parser.add_argument(
+        "--optimizer-translation-registry",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "mir-opt-translation-registry.json",
+    )
+    parser.add_argument(
+        "--corehir-body-boundary-receipt",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "corehir-body-boundary.json",
+    )
+    parser.add_argument("--release-provenance", type=Path, required=True)
+    parser.add_argument("--release-payload-manifest", type=Path, required=True)
+    parser.add_argument("--release-payload", action="append", required=True)
+    parser.add_argument("--expected-repository", required=True)
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--expected-tag", required=True)
+    parser.add_argument("--authorization-output", type=Path, required=True)
+    args = parser.parse_args()
+
+    release_payloads: dict[str, Path] = {}
+    for raw in args.release_payload:
+        name, path = parse_payload(raw)
+        if name in release_payloads:
+            raise ValueError(f"duplicate release payload name: {name}")
+        release_payloads[name] = path
+
+    paths = {
+        "source": args.source,
+        "producer_executable": args.producer_executable,
+        "typed_corehir": args.typed_corehir,
+        "verified_core_machine": args.verified_core_machine,
+        "verified_core_normalized": args.verified_core_normalized,
+        "solver_input": args.solver_input,
+        "boundary_registry": args.boundary_registry,
+        "boundary_registry_validation_receipt": args.boundary_registry_validation_receipt,
+        "backend_typeid_layout_receipt": args.backend_typeid_layout_receipt,
+        "optimizer_translation_registry": args.optimizer_translation_registry,
+        "corehir_body_boundary_receipt": args.corehir_body_boundary_receipt,
+        "release_provenance": args.release_provenance,
+        "release_payload_manifest": args.release_payload_manifest,
+    }
+    try:
+        mode, count = validate_proof_required_release(
+            args.policy,
+            args.source_binding,
+            paths,
+            expected_repository=args.expected_repository,
+            expected_commit=args.expected_commit,
+            expected_tag=args.expected_tag,
+            release_payloads=release_payloads,
+        )
+        artifact_paths = primary_release_artifact_paths(args.policy)
+        authorization = create_release_authorization(
+            repository=args.expected_repository,
+            commit_sha=args.expected_commit,
+            tag=args.expected_tag,
+            policy_path=args.policy,
+            source_binding_path=args.source_binding,
+            trust_manifest_path=artifact_paths["trust_manifest"],
+            proof_receipt_path=artifact_paths["receipt"],
+            payload_manifest_path=args.release_payload_manifest,
+        )
+        write_release_authorization(authorization, args.authorization_output)
+    except (
+        OSError,
+        ValueError,
+        ValidationError,
+        SourceProofBindingError,
+        ReleasePayloadError,
+        ReleaseProvenanceError,
+        ReleaseAuthorizationError,
+        ProofRequiredReleaseError,
+    ) as exc:
+        print(f"proof-required-release: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "proof-required-release: PASS: "
+        f"mode={mode} artifacts={count} tag={args.expected_tag} "
+        f"authorization={args.authorization_output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check/check-release-authorization.py
+++ b/scripts/check/check-release-authorization.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Verify release authorization before any external publish action."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.release_authorization import (  # noqa: E402
+    ReleaseAuthorizationError,
+    validate_bound_release_authorization,
+)
+from proof.release_payload import (  # noqa: E402
+    ReleasePayloadError,
+    validate_release_payload_manifest,
+)
+from proof.common import load_json  # noqa: E402
+
+
+def parse_payload(raw: str) -> tuple[str, Path]:
+    name, separator, path = raw.partition("=")
+    if not separator or not name or not path:
+        raise ValueError("--release-payload must be NAME=PATH")
+    return name, Path(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--authorization", type=Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--policy", type=Path, required=True)
+    parser.add_argument("--source-binding", type=Path, required=True)
+    parser.add_argument("--trust-manifest", type=Path, required=True)
+    parser.add_argument("--proof-receipt", type=Path, required=True)
+    parser.add_argument("--release-payload-manifest", type=Path, required=True)
+    parser.add_argument("--release-payload", action="append", required=True)
+    args = parser.parse_args()
+
+    payloads: dict[str, Path] = {}
+    for raw in args.release_payload:
+        name, path = parse_payload(raw)
+        if name in payloads:
+            raise ValueError(f"duplicate release payload name: {name}")
+        payloads[name] = path
+    try:
+        validate_release_payload_manifest(
+            load_json(args.release_payload_manifest),
+            payloads,
+        )
+        validate_bound_release_authorization(
+            args.authorization,
+            repository=args.repository,
+            commit_sha=args.commit,
+            tag=args.tag,
+            policy_path=args.policy,
+            source_binding_path=args.source_binding,
+            trust_manifest_path=args.trust_manifest,
+            proof_receipt_path=args.proof_receipt,
+            payload_manifest_path=args.release_payload_manifest,
+        )
+    except (OSError, ValueError, ReleaseAuthorizationError, ReleasePayloadError) as exc:
+        print(f"release-authorization: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "release-authorization: PASS: "
+        f"repository={args.repository} tag={args.tag} payloads={len(payloads)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check/check-versioned-boundary-enforcement.py
+++ b/scripts/check/check-versioned-boundary-enforcement.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Reject a versioned-boundary hard gate that is not wired through release proof."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.boundary_registry import REQUIRED_BOUNDARIES, load_registry  # noqa: E402
+from proof.source_proof_binding import REQUIRED_ARTIFACTS, VERSION as BINDING_VERSION  # noqa: E402
+
+POLICY = ROOT / "release" / "proof-policy.json"
+REGISTRY = ROOT / "release" / "boundary-registry.json"
+RELEASE_COMMAND = ROOT / "scripts" / "run" / "proof-required-release.sh"
+BINDING_WRITER = ROOT / "scripts" / "gen" / "write-source-proof-binding.py"
+RELEASE_CHECKER = ROOT / "scripts" / "check" / "check-proof-required-release.py"
+TOOLCHAIN_WRITER = ROOT / "scripts" / "gen" / "prepare-proof-release-toolchain.py"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "proof-required-release.yml"
+PROOF_WORKFLOW = ROOT / ".github" / "workflows" / "typed-contract-frontend.yml"
+REGISTRY_WORKFLOW = ROOT / ".github" / "workflows" / "versioned-boundary-registry.yml"
+ENFORCEMENT_RECEIPT = ROOT / "scripts" / "gen" / "write-proof-release-enforcement-receipt.py"
+
+
+def require(text: str, token: str, label: str) -> None:
+    if token not in text:
+        raise ValueError(f"missing {label}: {token}")
+
+
+def require_order(text: str, earlier: str, later: str, label: str) -> None:
+    left = text.find(earlier)
+    right = text.find(later)
+    if left < 0 or right < 0 or left >= right:
+        raise ValueError(f"invalid {label}: {earlier!r} must precede {later!r}")
+
+
+def main() -> int:
+    registry = load_registry(REGISTRY)
+    if set(registry["required_boundaries"]) != REQUIRED_BOUNDARIES:
+        raise ValueError("boundary registry does not cover the complete required set")
+
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    gates = policy.get("hard_gates")
+    if not isinstance(gates, dict) or gates.get("versioned_boundary_artifacts") is not True:
+        raise ValueError("release policy does not enable versioned_boundary_artifacts")
+
+    if BINDING_VERSION != 4:
+        raise ValueError(f"source proof binding must be v4, found v{BINDING_VERSION}")
+    required_binding_artifacts = {
+        "boundary_registry",
+        "boundary_registry_validation_receipt",
+    }
+    if not required_binding_artifacts <= set(REQUIRED_ARTIFACTS):
+        raise ValueError("source proof binding omits registry evidence")
+
+    release_command = RELEASE_COMMAND.read_text(encoding="utf-8")
+    binding_writer = BINDING_WRITER.read_text(encoding="utf-8")
+    release_checker = RELEASE_CHECKER.read_text(encoding="utf-8")
+    toolchain_writer = TOOLCHAIN_WRITER.read_text(encoding="utf-8")
+    release_workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    proof_workflow = PROOF_WORKFLOW.read_text(encoding="utf-8")
+    registry_workflow = REGISTRY_WORKFLOW.read_text(encoding="utf-8")
+    enforcement_receipt = ENFORCEMENT_RECEIPT.read_text(encoding="utf-8")
+
+    for token, label in (
+        ("check-boundary-registry.py", "registry validation command"),
+        ("check-boundary-registry-receipt.py", "independent registry receipt command"),
+        ("--boundary-registry", "source binding registry argument"),
+        ("--boundary-registry-validation-receipt", "source binding receipt argument"),
+        ("write-source-proof-binding.py", "source binding writer invocation"),
+        ("run-proof-solver.py", "solver invocation"),
+        ("--solver-result-output", "complete SolverResult output"),
+        ("check-proof-required-release.py", "release authorization invocation"),
+    ):
+        require(release_command, token, label)
+    require_order(
+        release_command,
+        "check-boundary-registry.py",
+        "check-boundary-registry-receipt.py",
+        "registry validation sequence",
+    )
+    require_order(
+        release_command,
+        "check-boundary-registry-receipt.py",
+        "write-source-proof-binding.py",
+        "registry-to-source-binding sequence",
+    )
+    require_order(
+        release_command,
+        "write-source-proof-binding.py",
+        "run-proof-solver.py",
+        "source-binding-to-solver sequence",
+    )
+
+    for text, label in (
+        (binding_writer, "source binding writer"),
+        (release_checker, "release checker"),
+    ):
+        require(text, '"boundary_registry"', f"{label} registry path map")
+        require(
+            text,
+            '"boundary_registry_validation_receipt"',
+            f"{label} validation receipt path map",
+        )
+
+    for token, label in (
+        ('"source-artifact-binding", "4"', "source binding v4 TrustManifest component"),
+        ('"major-boundary-registry"', "registry TrustManifest component"),
+        ('"major-boundary-registry-validator"', "registry validator TrustManifest component"),
+        ('"major-boundary-receipt-validator"', "receipt validator TrustManifest component"),
+        ('"major-boundary-receipt-checker"', "receipt checker TrustManifest component"),
+    ):
+        require(toolchain_writer, token, label)
+    if "source-proof-binding-v3" in toolchain_writer or '"source-artifact-binding", "3"' in toolchain_writer:
+        raise ValueError("legacy source-artifact-binding v3 remains in release toolchain")
+
+    for workflow, label in (
+        (release_workflow, "release workflow"),
+        (proof_workflow, "proof workflow"),
+    ):
+        require(workflow, "release/boundary-registry.json", f"{label} registry retention")
+        require(
+            workflow,
+            ".build/proof/boundary-registry-validation.json",
+            f"{label} validation receipt retention",
+        )
+        require(workflow, "test_boundary_registry", f"{label} registry negative tests")
+        require(workflow, "solver-result.json", f"{label} complete solver result")
+
+    for token, label in (
+        ("check-boundary-registry.py", "registry workflow generator"),
+        ("check-boundary-registry-receipt.py", "registry workflow independent checker"),
+        ("check-versioned-boundary-enforcement.py", "registry workflow integration checker"),
+        ("release/boundary-registry.json", "registry workflow artifact"),
+        ("boundary-registry-validation.json", "registry workflow receipt artifact"),
+    ):
+        require(registry_workflow, token, label)
+
+    for token, label in (
+        ('"release/boundary-registry.json"', "release enforcement registry binding"),
+        ('"scripts/proof/boundary_registry.py"', "release enforcement registry validator binding"),
+        ('"scripts/proof/boundary_registry_receipt.py"', "release enforcement receipt validator binding"),
+        ('"scripts/check/check-versioned-boundary-enforcement.py"', "release enforcement integration checker binding"),
+        ('"scripts/tests/test_boundary_registry.py"', "release enforcement negative tests binding"),
+        ('"scripts/tests/test_source_proof_binding.py"', "release enforcement binding-v4 tests"),
+        ("pinned major boundary registry and validation receipt", "authorization binding declaration"),
+    ):
+        require(enforcement_receipt, token, label)
+
+    print(
+        "versioned-boundary-enforcement: PASS: "
+        f"boundaries={len(REQUIRED_BOUNDARIES)} binding=v{BINDING_VERSION}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"versioned-boundary-enforcement: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/prepare-proof-release-toolchain.py
+++ b/scripts/gen/prepare-proof-release-toolchain.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Prepare the exact toolchain and validators trusted by a release proof run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+COMPONENTS = (
+    ("arukellt-source-proof-binding-v4", "source-artifact-binding", "4", None),
+    ("arukellt-source-proof-binding-validator-v4", "source-artifact-binding-validator", "4", "scripts/proof/source_proof_binding.py"),
+    ("arukellt-major-boundary-registry-v1", "major-boundary-registry", "1", "release/boundary-registry.json"),
+    ("arukellt-major-boundary-registry-validator-v1", "major-boundary-registry-validator", "1", "scripts/proof/boundary_registry.py"),
+    ("arukellt-major-boundary-receipt-validator-v1", "major-boundary-receipt-validator", "1", "scripts/proof/boundary_registry_receipt.py"),
+    ("arukellt-major-boundary-checker-v1", "major-boundary-checker", "1", "scripts/check/check-boundary-registry.py"),
+    ("arukellt-major-boundary-receipt-checker-v1", "major-boundary-receipt-checker", "1", "scripts/check/check-boundary-registry-receipt.py"),
+    ("arukellt-release-provenance-validator-v1", "release-provenance-validator", "1", "scripts/proof/release_provenance.py"),
+    ("arukellt-release-payload-validator-v1", "release-payload-validator", "1", "scripts/proof/release_payload.py"),
+    ("arukellt-release-gate-v1", "proof-required-release-gate", "1", "scripts/proof/release_gate.py"),
+    ("arukellt-release-authorization-v1", "release-authorization-writer", "1", "scripts/proof/release_authorization.py"),
+    ("arukellt-proof-release-cli-v1", "release-gate-cli", "1", "scripts/check/check-proof-required-release.py"),
+    ("arukellt-release-authorization-verifier-v1", "release-authorization-verifier", "1", "scripts/check/check-release-authorization.py"),
+    ("arukellt-release-entrypoint-policy-v1", "release-entrypoint-policy", "1", "scripts/check/check-proof-release-entrypoints.py"),
+    ("arukellt-proof-release-command-v1", "canonical-release-command", "1", "scripts/run/proof-required-release.sh"),
+    ("arukellt-proof-release-policy-writer-v1", "release-policy-writer", "1", "scripts/gen/write-proof-required-release-policy.py"),
+    ("arukellt-proof-release-enforcement-receipt-v1", "release-enforcement-receipt-writer", "1", "scripts/gen/write-proof-release-enforcement-receipt.py"),
+    ("arukellt-proof-trust-validator-v1", "trust-artifact-validator", "1", "scripts/proof/trust.py"),
+    ("arukellt-solver-receipt-generator-v1", "proof-receipt-generator", "1", "scripts/proof/solver_receipts.py"),
+    ("arukellt-solver-process-driver-v1", "solver-process-driver", "1", "scripts/proof/solver_driver.py"),
+    ("arukellt-solver-result-v1", "solver-result-validator", "1", "scripts/proof/solver_result.py"),
+    ("arukellt-solver-result-checker-v1", "solver-result-checker", "1", "scripts/check/check-solver-result.py"),
+    ("arukellt-solver-trust-receipt-v1", "solver-trust-receipt-validator", "1", "scripts/proof/solver_trust_boundary_receipt.py"),
+    ("arukellt-solver-trust-receipt-checker-v1", "solver-trust-receipt-checker", "1", "scripts/check/check-solver-trust-boundary-receipt.py"),
+    ("arukellt-proof-solver-cli-v1", "solver-driver-cli", "1", "scripts/run/run-proof-solver.py"),
+    ("arukellt-typed-corehir-validator-v1", "typed-corehir-validator", "1", "scripts/proof/typed_corehir.py"),
+    ("arukellt-typed-corehir-validator-impl-v1", "typed-corehir-validator-implementation", "1", "scripts/proof/typed_corehir_impl.py"),
+    ("arukellt-proof-common-v1", "proof-validation-library", "1", "scripts/proof/common.py"),
+    ("arukellt-typed-corehir-converter-v2", "typed-proof-boundary", "2", "scripts/proof/typed_corehir_typed_convert.py"),
+    ("arukellt-typed-corehir-converter-impl-v1", "typed-proof-boundary-implementation", "1", "scripts/proof/typed_corehir_convert.py"),
+    ("arukellt-source-contract-profile-normalizer-v1", "semantic-profile-normalizer", "1", "scripts/proof/normalize_source_contract_profile.py"),
+    ("arukellt-verified-core-structural-validator-v1", "artifact-validator", "1", "scripts/proof/verified_core.py"),
+    ("arukellt-verified-core-semantic-validator-v1", "typed-artifact-validator", "1", "scripts/proof/verified_core_typed.py"),
+    ("arukellt-typed-smt-adapter-v1", "typed-smt-adapter", "1", "scripts/proof/smtlib_typed_v1.py"),
+    ("arukellt-smt-renderer-v1", "smt-renderer-implementation", "1", "scripts/proof/smtlib_v1.py"),
+    ("arukellt-typed-boundary-policy-v1", "typed-boundary-policy", "1", "scripts/check/check-typed-verified-core-boundary.py"),
+    ("arukellt-typed-boundary-receipt-validator-v1", "typed-boundary-receipt-validator", "1", "scripts/proof/typed_verified_core_receipt.py"),
+    ("arukellt-typed-boundary-receipt-checker-v1", "typed-boundary-receipt-checker", "1", "scripts/check/check-typed-verified-core-boundary-receipt.py"),
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runtime", type=Path, required=True)
+    parser.add_argument("--source-binding", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--toolchain-output", type=Path, required=True)
+    parser.add_argument("--z3", type=Path, required=True)
+    args = parser.parse_args()
+
+    for label, path in (("runtime", args.runtime), ("source binding", args.source_binding), ("z3", args.z3)):
+        if not path.is_file():
+            raise ValueError(f"{label} missing: {path}")
+    output = args.output_dir
+    output.mkdir(parents=True, exist_ok=True)
+    runtime_name = "arukellt-s2-runtime.wasm"
+    z3_name = "z3"
+    binding_name = "source-proof-binding.json"
+    shutil.copy2(args.runtime, output / runtime_name)
+    shutil.copy2(args.z3, output / z3_name)
+    shutil.copy2(args.source_binding, output / binding_name)
+
+    trusted_components: list[dict[str, str]] = []
+    for name, role, version, relative in COMPONENTS:
+        if relative is None:
+            artifact_name = binding_name
+        else:
+            source = ROOT / relative
+            if not source.is_file():
+                raise ValueError(f"trusted component missing: {relative}")
+            artifact_name = source.name
+            destination = output / artifact_name
+            if destination.exists() and destination.read_bytes() != source.read_bytes():
+                raise ValueError(f"trusted component basename collision: {relative}")
+            shutil.copy2(source, destination)
+        trusted_components.append({"name": name, "role": role, "version": version, "artifact": artifact_name})
+
+    version = subprocess.check_output([str(args.z3), "--version"], text=True).strip()
+    document = {
+        "schema": "arukellt-proof-toolchain",
+        "schema_version": 1,
+        "producer": {
+            "name": "arukellt-selfhost-typed-contract-emitter",
+            "version": "current-s2-runtime",
+            "executable": runtime_name,
+            "arguments": ["compile", "tests/verified-core/contract_identity.ark", "--emit", "typed-corehir"],
+        },
+        "translator": {
+            "name": "arukellt-typed-verified-core-smtlib",
+            "version": "1",
+            "executable": "smtlib_typed_v1.py",
+        },
+        "solver": {
+            "name": "z3",
+            "version": version,
+            "executable": z3_name,
+            "arguments": ["-in", "-smt2"],
+        },
+        "semantic_profile": {
+            "integer_model": "mathematical",
+            "overflow": "checked",
+            "floating_point": "unsupported",
+            "memory": "pure-values",
+        },
+        "assumptions": [],
+        "trusted_components": trusted_components,
+        "limits": {"timeout_ms": 10000, "memory_bytes": 1073741824},
+    }
+    args.toolchain_output.parent.mkdir(parents=True, exist_ok=True)
+    args.toolchain_output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"proof-release-toolchain: PASS: components={len(trusted_components)} output={args.toolchain_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        print(f"proof-release-toolchain: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/write-proof-release-enforcement-receipt.py
+++ b/scripts/gen/write-proof-release-enforcement-receipt.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Write a hash-bound receipt for proof-required release enforcement."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BOUNDARY_FILES = (
+    ".github/workflows/proof-required-release.yml",
+    ".github/workflows/typed-contract-frontend.yml",
+    ".github/workflows/versioned-boundary-registry.yml",
+    "release/boundary-registry.json",
+    "scripts/run/proof-required-release.sh",
+    "scripts/check/check-boundary-registry.py",
+    "scripts/check/check-boundary-registry-receipt.py",
+    "scripts/check/check-versioned-boundary-enforcement.py",
+    "scripts/check/check-proof-release-entrypoints.py",
+    "scripts/check/check-proof-required-release.py",
+    "scripts/check/check-release-authorization.py",
+    "scripts/proof/boundary_registry.py",
+    "scripts/proof/boundary_registry_receipt.py",
+    "scripts/proof/release_gate.py",
+    "scripts/proof/release_provenance.py",
+    "scripts/proof/release_payload.py",
+    "scripts/proof/release_authorization.py",
+    "scripts/proof/source_proof_binding.py",
+    "scripts/gen/write-release-provenance.py",
+    "scripts/gen/write-release-payload-manifest.py",
+    "scripts/gen/write-source-proof-binding.py",
+    "scripts/gen/prepare-proof-release-toolchain.py",
+    "scripts/gen/write-proof-required-release-policy.py",
+    "scripts/tests/test_boundary_registry.py",
+    "scripts/tests/test_source_proof_binding.py",
+    "scripts/tests/test_proof_required_release_gate.py",
+    "scripts/tests/test_release_authorization.py",
+    "release/proof-policy.json",
+)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "proof-release-enforcement.json",
+    )
+    args = parser.parse_args()
+
+    files: list[dict[str, str]] = []
+    for relative in BOUNDARY_FILES:
+        path = ROOT / relative
+        if not path.is_file():
+            raise ValueError(f"release enforcement file missing: {relative}")
+        files.append({"path": relative, "sha256": sha256(path)})
+    document = {
+        "schema": "arukellt-proof-release-enforcement",
+        "schema_version": 1,
+        "status": "enforced",
+        "tag_pattern": "refs/tags/v*",
+        "authorization_required": True,
+        "authorization_binds": [
+            "repository",
+            "commit",
+            "tag",
+            "proof policy",
+            "source and architecture binding",
+            "pinned major boundary registry and validation receipt",
+            "TrustManifest",
+            "ProofReceipt",
+            "release payload manifest",
+        ],
+        "receipt_replay": "rejected",
+        "payload_substitution": "rejected",
+        "unguarded_publish_entrypoints": "rejected",
+        "files": files,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        "proof-release-enforcement-receipt: PASS: "
+        f"files={len(files)} output={args.output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"proof-release-enforcement-receipt: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/write-proof-required-release-policy.py
+++ b/scripts/gen/write-proof-required-release-policy.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Write the canonical proof-required release policy beside its proof bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--label", default="source-contract-identity")
+    args = parser.parse_args()
+    document = {
+        "schema": "arukellt-proof-release-policy",
+        "schema_version": 1,
+        "mode": "proof-required",
+        "hard_gates": {
+            "versioned_boundary_artifacts": True,
+            "explicit_backend_type_abi_layout": True,
+            "typed_verified_core_emission": True,
+            "optimizer_translation_validation": True,
+            "solver_trust_manifest": True,
+            "legacy_mutable_table_removed": True,
+            "proof_receipt_release_enforced": True,
+        },
+        "artifacts": [
+            {
+                "label": args.label,
+                "subject": "verified-core.json",
+                "trust_manifest": "trust-manifest.json",
+                "receipt": "proof-receipt.json",
+                "solver_output": "solver-output.txt",
+                "translation_receipts": [],
+            }
+        ],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"proof-required-release-policy: PASS: output={args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except OSError as exc:
+        print(f"proof-required-release-policy: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/write-release-payload-manifest.py
+++ b/scripts/gen/write-release-payload-manifest.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Write a hash-bound manifest for final release payloads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.release_payload import create_release_payload_manifest  # noqa: E402
+
+
+def parse_payload(raw: str) -> tuple[str, Path]:
+    name, separator, path = raw.partition("=")
+    if not separator or not name or not path:
+        raise ValueError("--payload must be NAME=PATH")
+    return name, Path(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--payload", action="append", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    payloads: dict[str, Path] = {}
+    for raw in args.payload:
+        name, path = parse_payload(raw)
+        if name in payloads:
+            raise ValueError(f"duplicate payload name: {name}")
+        payloads[name] = path
+    document = create_release_payload_manifest(payloads)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        "release-payload-manifest: PASS: "
+        f"artifacts={len(document['artifacts'])} output={args.output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"release-payload-manifest: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/write-release-provenance.py
+++ b/scripts/gen/write-release-provenance.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Write release commit/ref provenance for proof binding."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.release_provenance import create_release_provenance  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--commit", default=os.environ.get("GITHUB_SHA"))
+    parser.add_argument("--ref-type", choices=("tag", "branch", "pull_request"))
+    parser.add_argument("--ref-name", default=os.environ.get("GITHUB_REF_NAME"))
+    parser.add_argument("--workflow", default=os.environ.get("GITHUB_WORKFLOW", "local"))
+    parser.add_argument("--run-id", default=os.environ.get("GITHUB_RUN_ID", "local"))
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    ref_type = args.ref_type
+    if ref_type is None:
+        ref = os.environ.get("GITHUB_REF", "")
+        if ref.startswith("refs/tags/"):
+            ref_type = "tag"
+        elif ref.startswith("refs/pull/"):
+            ref_type = "pull_request"
+        else:
+            ref_type = "branch"
+    if not args.repository or not args.commit or not args.ref_name:
+        raise ValueError("repository, commit, and ref name are required")
+
+    document = create_release_provenance(
+        repository=args.repository,
+        commit_sha=args.commit,
+        ref_type=ref_type,
+        ref_name=args.ref_name,
+        workflow=args.workflow,
+        run_id=str(args.run_id),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        "release-provenance: PASS: "
+        f"repository={document['repository']} ref={document['ref_type']}:{document['ref_name']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as exc:
+        print(f"release-provenance: FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/gen/write-source-proof-binding.py
+++ b/scripts/gen/write-source-proof-binding.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Write a digest binding for a source-contract proof run."""
+"""Write a digest binding for source proof, architecture evidence, and release payload."""
 
 from __future__ import annotations
 
@@ -26,6 +26,33 @@ def main() -> int:
     parser.add_argument("--verified-core-machine", required=True, type=Path)
     parser.add_argument("--verified-core-normalized", required=True, type=Path)
     parser.add_argument("--solver-input", required=True, type=Path)
+    parser.add_argument(
+        "--boundary-registry",
+        type=Path,
+        default=ROOT / "release" / "boundary-registry.json",
+    )
+    parser.add_argument(
+        "--boundary-registry-validation-receipt",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "boundary-registry-validation.json",
+    )
+    parser.add_argument(
+        "--backend-typeid-layout-receipt",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "backend-typeid-layout.json",
+    )
+    parser.add_argument(
+        "--optimizer-translation-registry",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "mir-opt-translation-registry.json",
+    )
+    parser.add_argument(
+        "--corehir-body-boundary-receipt",
+        type=Path,
+        default=ROOT / ".build" / "proof" / "corehir-body-boundary.json",
+    )
+    parser.add_argument("--release-provenance", required=True, type=Path)
+    parser.add_argument("--release-payload-manifest", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
     args = parser.parse_args()
     write_binding(
@@ -36,6 +63,13 @@ def main() -> int:
             "verified_core_machine": args.verified_core_machine,
             "verified_core_normalized": args.verified_core_normalized,
             "solver_input": args.solver_input,
+            "boundary_registry": args.boundary_registry,
+            "boundary_registry_validation_receipt": args.boundary_registry_validation_receipt,
+            "backend_typeid_layout_receipt": args.backend_typeid_layout_receipt,
+            "optimizer_translation_registry": args.optimizer_translation_registry,
+            "corehir_body_boundary_receipt": args.corehir_body_boundary_receipt,
+            "release_provenance": args.release_provenance,
+            "release_payload_manifest": args.release_payload_manifest,
         },
         args.output,
     )

--- a/scripts/proof/boundary_registry.py
+++ b/scripts/proof/boundary_registry.py
@@ -1,0 +1,288 @@
+"""Independent validation for the pinned major-boundary registry.
+
+The registry is intentionally able to describe an unmerged PR stack. Every file
+reference is pinned to a full immutable commit SHA; branch names are never part
+of the trust decision. Validation may use a fake source in unit tests or fetch
+raw files from GitHub for an end-to-end registry check.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Protocol
+
+SCHEMA = "arukellt-boundary-registry"
+VERSION = 1
+REQUIRED_BOUNDARIES = {
+    "typed-corehir",
+    "corehir-body",
+    "verified-core",
+    "mir-optimizer",
+    "backend-layout",
+    "solver-result",
+    "release-authorization",
+}
+ARTIFACT_KINDS = {
+    "serialized-json",
+    "in-memory-snapshot",
+    "typed-mir-snapshot",
+}
+_SHA1 = re.compile(r"^[0-9a-f]{40}$")
+_REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+class BoundaryRegistryError(ValueError):
+    """The registry is malformed, incomplete, unpinned, or stale."""
+
+
+class BoundaryFileSource(Protocol):
+    def fetch(self, repository: str, commit: str, path: str) -> bytes:
+        """Return exact file bytes for a repository path at a commit."""
+
+
+@dataclass(frozen=True)
+class GitHubRawSource:
+    timeout_seconds: float = 20.0
+    user_agent: str = "arukellt-boundary-registry-v1"
+
+    def fetch(self, repository: str, commit: str, path: str) -> bytes:
+        owner, name = repository.split("/", 1)
+        encoded_path = "/".join(urllib.parse.quote(part, safe="") for part in path.split("/"))
+        url = (
+            "https://raw.githubusercontent.com/"
+            f"{urllib.parse.quote(owner, safe='')}/"
+            f"{urllib.parse.quote(name, safe='')}/{commit}/{encoded_path}"
+        )
+        request = urllib.request.Request(url, headers={"User-Agent": self.user_agent})
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                data = response.read()
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as exc:
+            raise BoundaryRegistryError(
+                f"unable to fetch {repository}@{commit}:{path}: {exc}"
+            ) from exc
+        if not data:
+            raise BoundaryRegistryError(f"empty boundary file: {repository}@{commit}:{path}")
+        return data
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise BoundaryRegistryError(message)
+
+
+def _object(value: object, path: str) -> dict[str, Any]:
+    _require(isinstance(value, dict), f"{path}: expected object")
+    return value
+
+
+def _exact_keys(value: dict[str, Any], expected: set[str], path: str) -> None:
+    _require(set(value) == expected, f"{path}: field set mismatch")
+
+
+def _string(value: object, path: str) -> str:
+    _require(isinstance(value, str) and bool(value), f"{path}: expected non-empty string")
+    return str(value)
+
+
+def _positive_int(value: object, path: str) -> int:
+    _require(type(value) is int and int(value) >= 1, f"{path}: expected integer >= 1")
+    return int(value)
+
+
+def _commit(value: object, path: str) -> str:
+    commit = _string(value, path)
+    _require(_SHA1.fullmatch(commit) is not None, f"{path}: expected full lowercase commit SHA")
+    return commit
+
+
+def _relative_path(value: object, path: str) -> str:
+    raw = _string(value, path)
+    candidate = Path(raw)
+    _require(not candidate.is_absolute(), f"{path}: absolute paths are forbidden")
+    _require(".." not in candidate.parts, f"{path}: path traversal is forbidden")
+    _require(raw == candidate.as_posix(), f"{path}: expected canonical POSIX path")
+    return raw
+
+
+def _tokens(value: object, path: str) -> list[str]:
+    _require(isinstance(value, list) and bool(value), f"{path}: expected non-empty array")
+    rendered = [_string(token, f"{path}[{index}]") for index, token in enumerate(value)]
+    _require(len(set(rendered)) == len(rendered), f"{path}: duplicate token")
+    return rendered
+
+
+def _file_ref(value: object, path: str) -> dict[str, Any]:
+    ref = _object(value, path)
+    _exact_keys(ref, {"commit", "path", "required_tokens"}, path)
+    _commit(ref["commit"], f"{path}.commit")
+    _relative_path(ref["path"], f"{path}.path")
+    _tokens(ref["required_tokens"], f"{path}.required_tokens")
+    return ref
+
+
+def _artifact(value: object, path: str) -> dict[str, Any]:
+    artifact = _object(value, path)
+    _exact_keys(artifact, {"schema", "schema_version", "kind"}, path)
+    _string(artifact["schema"], f"{path}.schema")
+    _positive_int(artifact["schema_version"], f"{path}.schema_version")
+    kind = _string(artifact["kind"], f"{path}.kind")
+    _require(kind in ARTIFACT_KINDS, f"{path}.kind: unsupported artifact kind {kind!r}")
+    return artifact
+
+
+def validate_registry(value: object) -> dict[str, Any]:
+    registry = _object(value, "$")
+    _exact_keys(
+        registry,
+        {
+            "schema",
+            "schema_version",
+            "status",
+            "repository",
+            "required_boundaries",
+            "boundaries",
+        },
+        "$",
+    )
+    _require(registry["schema"] == SCHEMA, f"$.schema: expected {SCHEMA!r}")
+    _require(registry["schema_version"] == VERSION, f"$.schema_version: expected {VERSION}")
+    _require(registry["status"] == "enforced", "$.status: expected enforced")
+    repository = _string(registry["repository"], "$.repository")
+    _require(_REPOSITORY.fullmatch(repository) is not None, "$.repository: expected owner/name")
+
+    required_raw = registry["required_boundaries"]
+    _require(isinstance(required_raw, list), "$.required_boundaries: expected array")
+    required = [_string(item, f"$.required_boundaries[{index}]") for index, item in enumerate(required_raw)]
+    _require(len(required) == len(set(required)), "$.required_boundaries: duplicate boundary")
+    _require(set(required) == REQUIRED_BOUNDARIES, "$.required_boundaries: required set mismatch")
+
+    boundaries_raw = registry["boundaries"]
+    _require(isinstance(boundaries_raw, list), "$.boundaries: expected array")
+    _require(len(boundaries_raw) == len(REQUIRED_BOUNDARIES), "$.boundaries: boundary count mismatch")
+
+    ids: set[str] = set()
+    schemas: set[tuple[str, int]] = set()
+    for index, raw in enumerate(boundaries_raw):
+        path = f"$.boundaries[{index}]"
+        boundary = _object(raw, path)
+        _exact_keys(
+            boundary,
+            {
+                "id",
+                "artifact",
+                "producer",
+                "validator",
+                "consumers",
+                "evidence",
+                "workflow",
+                "failure_action",
+            },
+            path,
+        )
+        boundary_id = _string(boundary["id"], f"{path}.id")
+        _require(boundary_id in REQUIRED_BOUNDARIES, f"{path}.id: unknown boundary {boundary_id!r}")
+        _require(boundary_id not in ids, f"{path}.id: duplicate boundary {boundary_id!r}")
+        ids.add(boundary_id)
+
+        artifact = _artifact(boundary["artifact"], f"{path}.artifact")
+        identity = (str(artifact["schema"]), int(artifact["schema_version"]))
+        _require(identity not in schemas, f"{path}.artifact: duplicate schema identity {identity}")
+        schemas.add(identity)
+
+        producer = _file_ref(boundary["producer"], f"{path}.producer")
+        validator = _file_ref(boundary["validator"], f"{path}.validator")
+        _require(
+            (producer["commit"], producer["path"]) != (validator["commit"], validator["path"]),
+            f"{path}: producer and validator must be independent files",
+        )
+
+        consumers = boundary["consumers"]
+        _require(isinstance(consumers, list) and bool(consumers), f"{path}.consumers: expected non-empty array")
+        consumer_refs: set[tuple[str, str]] = set()
+        for consumer_index, consumer_raw in enumerate(consumers):
+            consumer = _file_ref(consumer_raw, f"{path}.consumers[{consumer_index}]")
+            key = (str(consumer["commit"]), str(consumer["path"]))
+            _require(key not in consumer_refs, f"{path}.consumers: duplicate consumer reference")
+            consumer_refs.add(key)
+
+        _file_ref(boundary["evidence"], f"{path}.evidence")
+        _file_ref(boundary["workflow"], f"{path}.workflow")
+        _string(boundary["failure_action"], f"{path}.failure_action")
+
+    _require(ids == REQUIRED_BOUNDARIES, "$.boundaries: incomplete major-boundary coverage")
+    return registry
+
+
+def iter_file_references(registry: Mapping[str, Any]) -> Iterable[tuple[str, Mapping[str, Any]]]:
+    for boundary in registry["boundaries"]:
+        boundary_id = boundary["id"]
+        yield f"{boundary_id}.producer", boundary["producer"]
+        yield f"{boundary_id}.validator", boundary["validator"]
+        for index, consumer in enumerate(boundary["consumers"]):
+            yield f"{boundary_id}.consumer[{index}]", consumer
+        yield f"{boundary_id}.evidence", boundary["evidence"]
+        yield f"{boundary_id}.workflow", boundary["workflow"]
+
+
+def validate_registry_files(
+    registry: Mapping[str, Any],
+    source: BoundaryFileSource,
+) -> dict[tuple[str, str], bytes]:
+    validated = validate_registry(dict(registry))
+    repository = str(validated["repository"])
+    fetched: dict[tuple[str, str], bytes] = {}
+    for label, ref in iter_file_references(validated):
+        key = (str(ref["commit"]), str(ref["path"]))
+        data = fetched.get(key)
+        if data is None:
+            data = source.fetch(repository, key[0], key[1])
+            _require(bool(data), f"{label}: referenced file is empty")
+            fetched[key] = data
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise BoundaryRegistryError(f"{label}: referenced file is not UTF-8") from exc
+        for token in ref["required_tokens"]:
+            _require(token in text, f"{label}: required token missing: {token!r}")
+    return fetched
+
+
+def load_registry(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise BoundaryRegistryError(f"invalid registry JSON: {exc}") from exc
+    return validate_registry(value)
+
+
+__all__ = [
+    "ARTIFACT_KINDS",
+    "BoundaryFileSource",
+    "BoundaryRegistryError",
+    "GitHubRawSource",
+    "REQUIRED_BOUNDARIES",
+    "SCHEMA",
+    "VERSION",
+    "iter_file_references",
+    "load_registry",
+    "sha256_bytes",
+    "sha256_file",
+    "validate_registry",
+    "validate_registry_files",
+]

--- a/scripts/proof/boundary_registry_receipt.py
+++ b/scripts/proof/boundary_registry_receipt.py
@@ -1,0 +1,179 @@
+"""Versioned validation receipt for the pinned major-boundary registry."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from proof.boundary_registry import (
+    BoundaryFileSource,
+    BoundaryRegistryError,
+    iter_file_references,
+    load_registry,
+    sha256_bytes,
+    sha256_file,
+    validate_registry_files,
+)
+
+SCHEMA = "arukellt-boundary-registry-validation"
+VERSION = 1
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class BoundaryRegistryReceiptError(ValueError):
+    """A boundary-registry validation receipt is malformed or stale."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise BoundaryRegistryReceiptError(message)
+
+
+def _file_key(value: dict[str, Any]) -> tuple[str, str]:
+    return str(value["commit"]), str(value["path"])
+
+
+def create_validation_receipt(
+    registry_path: Path,
+    source: BoundaryFileSource,
+) -> dict[str, Any]:
+    registry = load_registry(registry_path)
+    fetched = validate_registry_files(registry, source)
+    boundaries = [
+        {
+            "id": boundary["id"],
+            "schema": boundary["artifact"]["schema"],
+            "schema_version": boundary["artifact"]["schema_version"],
+            "kind": boundary["artifact"]["kind"],
+        }
+        for boundary in registry["boundaries"]
+    ]
+    files = [
+        {
+            "commit": commit,
+            "path": path,
+            "sha256": sha256_bytes(data),
+            "size_bytes": len(data),
+        }
+        for (commit, path), data in sorted(fetched.items())
+    ]
+    return {
+        "schema": SCHEMA,
+        "schema_version": VERSION,
+        "status": "validated",
+        "repository": registry["repository"],
+        "registry_sha256": sha256_file(registry_path),
+        "boundary_count": len(boundaries),
+        "boundaries": boundaries,
+        "files": files,
+    }
+
+
+def write_validation_receipt(value: dict[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(output.name + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(output)
+
+
+def validate_validation_receipt(
+    value: object,
+    *,
+    registry_path: Path,
+    source: BoundaryFileSource | None = None,
+) -> dict[str, Any]:
+    _require(isinstance(value, dict), "receipt must be an object")
+    receipt = value
+    expected_fields = {
+        "schema",
+        "schema_version",
+        "status",
+        "repository",
+        "registry_sha256",
+        "boundary_count",
+        "boundaries",
+        "files",
+    }
+    _require(set(receipt) == expected_fields, "receipt field set mismatch")
+    _require(receipt["schema"] == SCHEMA, f"receipt schema must be {SCHEMA}")
+    _require(receipt["schema_version"] == VERSION, f"receipt schema_version must be {VERSION}")
+    _require(receipt["status"] == "validated", "receipt status must be validated")
+
+    registry = load_registry(registry_path)
+    _require(receipt["repository"] == registry["repository"], "receipt repository mismatch")
+    _require(
+        receipt["registry_sha256"] == sha256_file(registry_path),
+        "receipt does not bind the supplied registry",
+    )
+
+    expected_boundaries = [
+        {
+            "id": boundary["id"],
+            "schema": boundary["artifact"]["schema"],
+            "schema_version": boundary["artifact"]["schema_version"],
+            "kind": boundary["artifact"]["kind"],
+        }
+        for boundary in registry["boundaries"]
+    ]
+    _require(receipt["boundary_count"] == len(expected_boundaries), "boundary count mismatch")
+    _require(receipt["boundaries"] == expected_boundaries, "boundary inventory mismatch")
+
+    files = receipt["files"]
+    _require(isinstance(files, list) and bool(files), "receipt files must be a non-empty array")
+    by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    for index, raw in enumerate(files):
+        _require(isinstance(raw, dict), f"files[{index}] must be an object")
+        _require(
+            set(raw) == {"commit", "path", "sha256", "size_bytes"},
+            f"files[{index}] field set mismatch",
+        )
+        commit = raw["commit"]
+        path = raw["path"]
+        digest = raw["sha256"]
+        size = raw["size_bytes"]
+        _require(isinstance(commit, str) and len(commit) == 40, f"files[{index}].commit invalid")
+        _require(isinstance(path, str) and bool(path), f"files[{index}].path invalid")
+        _require(isinstance(digest, str) and _SHA256.fullmatch(digest) is not None, f"files[{index}].sha256 invalid")
+        _require(type(size) is int and size > 0, f"files[{index}].size_bytes invalid")
+        key = (commit, path)
+        _require(key not in by_key, f"duplicate receipt file: {commit}:{path}")
+        by_key[key] = raw
+
+    expected_keys = {
+        (str(ref["commit"]), str(ref["path"]))
+        for _, ref in iter_file_references(registry)
+    }
+    _require(set(by_key) == expected_keys, "receipt file reference set mismatch")
+
+    if source is not None:
+        try:
+            fetched = validate_registry_files(registry, source)
+        except BoundaryRegistryError as exc:
+            raise BoundaryRegistryReceiptError(str(exc)) from exc
+        for key, data in fetched.items():
+            entry = by_key[key]
+            _require(entry["sha256"] == sha256_bytes(data), f"stale receipt digest: {key[0]}:{key[1]}")
+            _require(entry["size_bytes"] == len(data), f"stale receipt size: {key[0]}:{key[1]}")
+    return receipt
+
+
+def load_validation_receipt(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise BoundaryRegistryReceiptError(f"invalid receipt JSON: {exc}") from exc
+    _require(isinstance(value, dict), "receipt must be an object")
+    return value
+
+
+__all__ = [
+    "BoundaryRegistryReceiptError",
+    "SCHEMA",
+    "VERSION",
+    "create_validation_receipt",
+    "load_validation_receipt",
+    "validate_validation_receipt",
+    "write_validation_receipt",
+]

--- a/scripts/proof/release_authorization.py
+++ b/scripts/proof/release_authorization.py
@@ -1,0 +1,145 @@
+"""Authorization artifact emitted only after the complete proof release gate passes."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from proof.common import load_json, sha256_file
+
+SCHEMA = "arukellt-proof-release-authorization"
+VERSION = 1
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReleaseAuthorizationError(ValueError):
+    """A release authorization artifact is malformed or stale."""
+
+
+def create_release_authorization(
+    *,
+    repository: str,
+    commit_sha: str,
+    tag: str,
+    policy_path: Path,
+    source_binding_path: Path,
+    trust_manifest_path: Path,
+    proof_receipt_path: Path,
+    payload_manifest_path: Path,
+) -> dict[str, object]:
+    return {
+        "schema": SCHEMA,
+        "schema_version": VERSION,
+        "status": "authorized",
+        "repository": repository,
+        "commit_sha": commit_sha.lower(),
+        "tag": tag,
+        "policy_sha256": sha256_file(policy_path),
+        "source_binding_sha256": sha256_file(source_binding_path),
+        "trust_manifest_sha256": sha256_file(trust_manifest_path),
+        "proof_receipt_sha256": sha256_file(proof_receipt_path),
+        "release_payload_manifest_sha256": sha256_file(payload_manifest_path),
+    }
+
+
+def write_release_authorization(document: dict[str, object], output: Path) -> None:
+    validate_release_authorization(document)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def validate_release_authorization(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ReleaseAuthorizationError("release authorization must be an object")
+    expected = {
+        "schema",
+        "schema_version",
+        "status",
+        "repository",
+        "commit_sha",
+        "tag",
+        "policy_sha256",
+        "source_binding_sha256",
+        "trust_manifest_sha256",
+        "proof_receipt_sha256",
+        "release_payload_manifest_sha256",
+    }
+    if set(value) != expected:
+        raise ReleaseAuthorizationError("release authorization fields mismatch")
+    if value.get("schema") != SCHEMA or value.get("schema_version") != VERSION:
+        raise ReleaseAuthorizationError("release authorization schema identity mismatch")
+    if value.get("status") != "authorized":
+        raise ReleaseAuthorizationError("release authorization status must be authorized")
+    for field in ("repository", "commit_sha", "tag"):
+        if not isinstance(value.get(field), str) or not value[field]:
+            raise ReleaseAuthorizationError(f"{field}: expected non-empty string")
+    commit = str(value["commit_sha"])
+    if not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise ReleaseAuthorizationError("commit_sha: expected full commit SHA")
+    for field in (
+        "policy_sha256",
+        "source_binding_sha256",
+        "trust_manifest_sha256",
+        "proof_receipt_sha256",
+        "release_payload_manifest_sha256",
+    ):
+        digest = value.get(field)
+        if not isinstance(digest, str) or not _SHA256.fullmatch(digest):
+            raise ReleaseAuthorizationError(f"{field}: expected SHA-256")
+    return value
+
+
+def validate_bound_release_authorization(
+    authorization_path: Path,
+    *,
+    repository: str,
+    commit_sha: str,
+    tag: str,
+    policy_path: Path,
+    source_binding_path: Path,
+    trust_manifest_path: Path,
+    proof_receipt_path: Path,
+    payload_manifest_path: Path,
+) -> dict[str, object]:
+    authorization = validate_release_authorization(load_json(authorization_path))
+    expected_identity = {
+        "repository": repository,
+        "commit_sha": commit_sha.lower(),
+        "tag": tag,
+    }
+    for field, expected in expected_identity.items():
+        if authorization.get(field) != expected:
+            raise ReleaseAuthorizationError(
+                f"{field} mismatch: expected {expected}, got {authorization.get(field)}"
+            )
+    bound_files = {
+        "policy_sha256": policy_path,
+        "source_binding_sha256": source_binding_path,
+        "trust_manifest_sha256": trust_manifest_path,
+        "proof_receipt_sha256": proof_receipt_path,
+        "release_payload_manifest_sha256": payload_manifest_path,
+    }
+    for field, path in bound_files.items():
+        if not path.is_file():
+            raise ReleaseAuthorizationError(f"{field}: file not found: {path}")
+        digest = sha256_file(path)
+        if authorization.get(field) != digest:
+            raise ReleaseAuthorizationError(
+                f"{field} mismatch: expected {digest}, got {authorization.get(field)}"
+            )
+    return authorization
+
+
+__all__ = [
+    "SCHEMA",
+    "VERSION",
+    "ReleaseAuthorizationError",
+    "create_release_authorization",
+    "validate_bound_release_authorization",
+    "validate_release_authorization",
+    "write_release_authorization",
+]

--- a/scripts/proof/release_gate.py
+++ b/scripts/proof/release_gate.py
@@ -1,0 +1,166 @@
+"""Fail-closed proof-required release validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from proof.common import load_json, sha256_file
+from proof.release_payload import validate_release_payload_manifest
+from proof.release_provenance import validate_release_provenance
+from proof.source_proof_binding import REQUIRED_ARTIFACTS, validate_binding
+from proof.trust import check_release_policy, validate_trust_manifest
+
+
+class ProofRequiredReleaseError(ValueError):
+    """The release proof chain is incomplete, stale, or not hash-bound."""
+
+
+def _resolve_policy_file(base: Path, raw: object, label: str) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise ProofRequiredReleaseError(f"{label}: expected relative path")
+    candidate = Path(raw)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise ProofRequiredReleaseError(f"{label}: expected relative path without '..'")
+    resolved = (base / candidate).resolve()
+    if resolved != base and base not in resolved.parents:
+        raise ProofRequiredReleaseError(f"{label}: path escapes policy directory")
+    if not resolved.is_file():
+        raise ProofRequiredReleaseError(f"{label}: file not found: {resolved}")
+    return resolved
+
+
+def primary_release_artifact_paths(policy_path: Path) -> dict[str, Path]:
+    policy = load_json(policy_path)
+    if not isinstance(policy, dict):
+        raise ProofRequiredReleaseError("release policy must be an object")
+    artifacts = policy.get("artifacts")
+    if not isinstance(artifacts, list) or len(artifacts) != 1:
+        raise ProofRequiredReleaseError(
+            "source-bound proof-required release requires exactly one artifact entry"
+        )
+    artifact = artifacts[0]
+    if not isinstance(artifact, dict):
+        raise ProofRequiredReleaseError("release artifact entry must be an object")
+    base = policy_path.parent.resolve()
+    return {
+        field: _resolve_policy_file(base, artifact.get(field), f"release artifact {field}")
+        for field in ("subject", "trust_manifest", "receipt", "solver_output")
+    }
+
+
+def _trusted_component(
+    manifest: dict[str, object],
+    *,
+    role: str,
+) -> dict[str, object]:
+    components = manifest.get("trusted_components")
+    if not isinstance(components, list):
+        raise ProofRequiredReleaseError("TrustManifest trusted_components must be an array")
+    matching = [
+        component
+        for component in components
+        if isinstance(component, dict) and component.get("role") == role
+    ]
+    if len(matching) != 1:
+        raise ProofRequiredReleaseError(
+            f"TrustManifest must contain exactly one component with role={role!r}"
+        )
+    return matching[0]
+
+
+def validate_proof_required_release(
+    policy_path: Path,
+    source_binding_path: Path,
+    bound_paths: Mapping[str, Path],
+    *,
+    expected_repository: str,
+    expected_commit: str,
+    expected_tag: str,
+    release_payloads: Mapping[str, Path],
+) -> tuple[str, int]:
+    mode, artifact_count = check_release_policy(policy_path)
+    if mode != "proof-required":
+        raise ProofRequiredReleaseError(
+            f"release policy mode must be proof-required, found {mode!r}"
+        )
+
+    missing = [name for name in REQUIRED_ARTIFACTS if name not in bound_paths]
+    if missing:
+        raise ProofRequiredReleaseError(f"missing source binding path(s): {missing}")
+    if not source_binding_path.is_file():
+        raise ProofRequiredReleaseError(
+            f"source proof binding file not found: {source_binding_path}"
+        )
+    validate_binding(load_json(source_binding_path), bound_paths)
+
+    validate_release_provenance(
+        load_json(bound_paths["release_provenance"]),
+        expected_repository=expected_repository,
+        expected_commit=expected_commit,
+        expected_tag=expected_tag,
+    )
+    validate_release_payload_manifest(
+        load_json(bound_paths["release_payload_manifest"]),
+        release_payloads,
+    )
+
+    artifact_paths = primary_release_artifact_paths(policy_path)
+    manifest = validate_trust_manifest(load_json(artifact_paths["trust_manifest"]))
+
+    binding_component = _trusted_component(
+        manifest,
+        role="source-artifact-binding",
+    )
+    binding_digest = sha256_file(source_binding_path)
+    if binding_component.get("artifact_sha256") != binding_digest:
+        raise ProofRequiredReleaseError(
+            "TrustManifest does not bind the supplied source proof binding"
+        )
+    if binding_component.get("version") != "4":
+        raise ProofRequiredReleaseError(
+            "TrustManifest must identify source-artifact-binding version 4"
+        )
+
+    producer_path = bound_paths["producer_executable"]
+    producer_digest = sha256_file(producer_path)
+    producer = manifest.get("producer")
+    if not isinstance(producer, dict):
+        raise ProofRequiredReleaseError("TrustManifest producer must be an object")
+    if producer.get("executable_sha256") != producer_digest:
+        raise ProofRequiredReleaseError(
+            "TrustManifest producer does not bind the supplied compiler executable"
+        )
+
+    release_binary = release_payloads.get("arukellt-wasm")
+    if release_binary is None:
+        raise ProofRequiredReleaseError(
+            "release payload must contain the canonical arukellt-wasm artifact"
+        )
+    if sha256_file(release_binary) != producer_digest:
+        raise ProofRequiredReleaseError(
+            "authorized arukellt-wasm payload is not the proved producer executable"
+        )
+
+    normalized_subject = bound_paths["verified_core_normalized"]
+    normalized_digest = sha256_file(normalized_subject)
+    manifest_subject = manifest.get("subject")
+    if not isinstance(manifest_subject, dict):
+        raise ProofRequiredReleaseError("TrustManifest subject must be an object")
+    if manifest_subject.get("sha256") != normalized_digest:
+        raise ProofRequiredReleaseError(
+            "TrustManifest proof subject is not the normalized VerifiedCore in the source binding"
+        )
+    if sha256_file(artifact_paths["subject"]) != normalized_digest:
+        raise ProofRequiredReleaseError(
+            "release policy subject is not the normalized VerifiedCore in the source binding"
+        )
+
+    return mode, artifact_count
+
+
+__all__ = [
+    "ProofRequiredReleaseError",
+    "primary_release_artifact_paths",
+    "validate_proof_required_release",
+]

--- a/scripts/proof/release_payload.py
+++ b/scripts/proof/release_payload.py
@@ -1,0 +1,103 @@
+"""Versioned manifest binding the exact files authorized for release."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from proof.common import sha256_file
+
+SCHEMA = "arukellt-release-payload-manifest"
+VERSION = 1
+
+
+class ReleasePayloadError(ValueError):
+    """The release payload manifest is missing, stale, or ambiguous."""
+
+
+def create_release_payload_manifest(
+    payloads: Mapping[str, Path],
+) -> dict[str, object]:
+    if not payloads:
+        raise ReleasePayloadError("release payload must contain at least one file")
+    entries: list[dict[str, object]] = []
+    seen_paths: set[Path] = set()
+    for name in sorted(payloads):
+        if not name or any(ch.isspace() for ch in name):
+            raise ReleasePayloadError(f"invalid payload name: {name!r}")
+        path = payloads[name]
+        if not path.is_file():
+            raise ReleasePayloadError(f"{name}: file not found: {path}")
+        resolved = path.resolve()
+        if resolved in seen_paths:
+            raise ReleasePayloadError(f"duplicate payload path: {path}")
+        seen_paths.add(resolved)
+        entries.append(
+            {
+                "name": name,
+                "sha256": sha256_file(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+    return {
+        "schema": SCHEMA,
+        "schema_version": VERSION,
+        "artifacts": entries,
+    }
+
+
+def validate_release_payload_manifest(
+    value: object,
+    payloads: Mapping[str, Path],
+) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ReleasePayloadError("release payload manifest must be an object")
+    if set(value) != {"schema", "schema_version", "artifacts"}:
+        raise ReleasePayloadError("release payload manifest fields mismatch")
+    if value.get("schema") != SCHEMA or value.get("schema_version") != VERSION:
+        raise ReleasePayloadError("release payload manifest schema identity mismatch")
+    entries = value.get("artifacts")
+    if not isinstance(entries, list) or not entries:
+        raise ReleasePayloadError("release payload manifest must list artifacts")
+
+    by_name: dict[str, dict[str, object]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or set(entry) != {"name", "sha256", "size_bytes"}:
+            raise ReleasePayloadError("invalid release payload entry")
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            raise ReleasePayloadError("release payload entry has invalid name")
+        if name in by_name:
+            raise ReleasePayloadError(f"duplicate release payload: {name}")
+        by_name[name] = entry
+
+    if set(by_name) != set(payloads):
+        raise ReleasePayloadError(
+            f"release payload set mismatch: manifest={sorted(by_name)} supplied={sorted(payloads)}"
+        )
+    seen_paths: set[Path] = set()
+    for name, path in payloads.items():
+        if not path.is_file():
+            raise ReleasePayloadError(f"{name}: file not found: {path}")
+        resolved = path.resolve()
+        if resolved in seen_paths:
+            raise ReleasePayloadError(f"duplicate supplied payload path: {path}")
+        seen_paths.add(resolved)
+        entry = by_name[name]
+        digest = sha256_file(path)
+        if entry.get("sha256") != digest:
+            raise ReleasePayloadError(
+                f"{name}: payload digest mismatch: expected {digest}, got {entry.get('sha256')}"
+            )
+        if entry.get("size_bytes") != path.stat().st_size:
+            raise ReleasePayloadError(f"{name}: payload size mismatch")
+    return value
+
+
+__all__ = [
+    "SCHEMA",
+    "VERSION",
+    "ReleasePayloadError",
+    "create_release_payload_manifest",
+    "validate_release_payload_manifest",
+]

--- a/scripts/proof/release_provenance.py
+++ b/scripts/proof/release_provenance.py
@@ -1,0 +1,120 @@
+"""Versioned provenance for a proof-authorized release invocation."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+SCHEMA = "arukellt-release-provenance"
+VERSION = 1
+_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+_REF_TYPES = {"tag", "branch", "pull_request"}
+
+
+class ReleaseProvenanceError(ValueError):
+    """Release provenance is malformed or does not match the active release."""
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ReleaseProvenanceError(f"{label}: expected non-empty string")
+    return value
+
+
+def _commit(value: object, label: str) -> str:
+    text = _text(value, label).lower()
+    if not _COMMIT_SHA.fullmatch(text):
+        raise ReleaseProvenanceError(f"{label}: expected full 40-character commit SHA")
+    return text
+
+
+def create_release_provenance(
+    *,
+    repository: str,
+    commit_sha: str,
+    ref_type: str,
+    ref_name: str,
+    workflow: str,
+    run_id: str,
+) -> dict[str, object]:
+    document = {
+        "schema": SCHEMA,
+        "schema_version": VERSION,
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "ref_type": ref_type,
+        "ref_name": ref_name,
+        "workflow": workflow,
+        "run_id": run_id,
+    }
+    return validate_release_provenance(document)
+
+
+def validate_release_provenance(
+    value: object,
+    *,
+    expected_repository: str | None = None,
+    expected_commit: str | None = None,
+    expected_tag: str | None = None,
+) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ReleaseProvenanceError("release provenance must be an object")
+    expected_keys = {
+        "schema",
+        "schema_version",
+        "repository",
+        "commit_sha",
+        "ref_type",
+        "ref_name",
+        "workflow",
+        "run_id",
+    }
+    if set(value) != expected_keys:
+        raise ReleaseProvenanceError(
+            f"release provenance fields mismatch: {sorted(value)}"
+        )
+    if value.get("schema") != SCHEMA or value.get("schema_version") != VERSION:
+        raise ReleaseProvenanceError("release provenance schema identity mismatch")
+
+    repository = _text(value.get("repository"), "repository")
+    if repository.count("/") != 1 or any(ch.isspace() for ch in repository):
+        raise ReleaseProvenanceError("repository: expected owner/name")
+    commit_sha = _commit(value.get("commit_sha"), "commit_sha")
+    ref_type = _text(value.get("ref_type"), "ref_type")
+    if ref_type not in _REF_TYPES:
+        raise ReleaseProvenanceError(f"ref_type: unsupported value {ref_type!r}")
+    ref_name = _text(value.get("ref_name"), "ref_name")
+    if any(ch.isspace() for ch in ref_name):
+        raise ReleaseProvenanceError("ref_name: whitespace is not allowed")
+    _text(value.get("workflow"), "workflow")
+    _text(value.get("run_id"), "run_id")
+
+    if expected_repository is not None and repository != expected_repository:
+        raise ReleaseProvenanceError(
+            f"repository mismatch: expected {expected_repository}, got {repository}"
+        )
+    if expected_commit is not None and commit_sha != _commit(expected_commit, "expected_commit"):
+        raise ReleaseProvenanceError(
+            f"commit mismatch: expected {expected_commit.lower()}, got {commit_sha}"
+        )
+    if expected_tag is not None:
+        if ref_type != "tag":
+            raise ReleaseProvenanceError(
+                f"proof-required release requires ref_type='tag', got {ref_type!r}"
+            )
+        if ref_name != expected_tag:
+            raise ReleaseProvenanceError(
+                f"tag mismatch: expected {expected_tag}, got {ref_name}"
+            )
+        if not ref_name.startswith("v"):
+            raise ReleaseProvenanceError("proof-required release tag must start with 'v'")
+    return value
+
+
+__all__ = [
+    "SCHEMA",
+    "VERSION",
+    "ReleaseProvenanceError",
+    "create_release_provenance",
+    "validate_release_provenance",
+]

--- a/scripts/proof/source_proof_binding.py
+++ b/scripts/proof/source_proof_binding.py
@@ -1,4 +1,4 @@
-"""Digest binding for the source-contract proof pipeline."""
+"""Digest binding for the source-contract and proof-authorized release pipeline."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Mapping
 
 SCHEMA = "arukellt-source-proof-binding"
-VERSION = 1
+VERSION = 4
 REQUIRED_ARTIFACTS = (
     "source",
     "producer_executable",
@@ -16,6 +16,13 @@ REQUIRED_ARTIFACTS = (
     "verified_core_machine",
     "verified_core_normalized",
     "solver_input",
+    "boundary_registry",
+    "boundary_registry_validation_receipt",
+    "backend_typeid_layout_receipt",
+    "optimizer_translation_registry",
+    "corehir_body_boundary_receipt",
+    "release_provenance",
+    "release_payload_manifest",
 )
 
 
@@ -67,6 +74,8 @@ def write_binding(paths: Mapping[str, Path], output: Path) -> dict[str, object]:
 def validate_binding(value: object, paths: Mapping[str, Path]) -> dict[str, object]:
     if not isinstance(value, dict):
         raise SourceProofBindingError("binding must be an object")
+    if set(value) != {"schema", "schema_version", "artifacts"}:
+        raise SourceProofBindingError("binding fields mismatch")
     if value.get("schema") != SCHEMA or value.get("schema_version") != VERSION:
         raise SourceProofBindingError("binding schema identity mismatch")
     entries = value.get("artifacts")
@@ -74,11 +83,15 @@ def validate_binding(value: object, paths: Mapping[str, Path]) -> dict[str, obje
         raise SourceProofBindingError("binding artifacts must be an array")
     by_name: dict[str, dict[str, object]] = {}
     for entry in entries:
-        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+        if not isinstance(entry, dict) or set(entry) != {"name", "path", "sha256"}:
             raise SourceProofBindingError("invalid binding artifact entry")
-        name = str(entry["name"])
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            raise SourceProofBindingError("invalid binding artifact name")
         if name in by_name:
             raise SourceProofBindingError(f"duplicate binding artifact: {name}")
+        if not isinstance(entry.get("path"), str) or not entry["path"]:
+            raise SourceProofBindingError(f"{name}: invalid bound path")
         by_name[name] = entry
     if set(by_name) != set(REQUIRED_ARTIFACTS):
         raise SourceProofBindingError(
@@ -88,8 +101,13 @@ def validate_binding(value: object, paths: Mapping[str, Path]) -> dict[str, obje
         path = paths.get(name)
         if path is None or not path.is_file():
             raise SourceProofBindingError(f"{name}: file not found")
+        entry = by_name[name]
+        if entry.get("path") != path.as_posix():
+            raise SourceProofBindingError(
+                f"{name}: path mismatch: expected {path.as_posix()}, got {entry.get('path')}"
+            )
         expected = sha256_file(path)
-        actual = by_name[name].get("sha256")
+        actual = entry.get("sha256")
         if actual != expected:
             raise SourceProofBindingError(
                 f"{name}: digest mismatch: expected {expected}, got {actual}"

--- a/scripts/run/proof-required-release.sh
+++ b/scripts/run/proof-required-release.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+: "${GITHUB_REF:?GITHUB_REF is required}"
+: "${GITHUB_REF_NAME:?GITHUB_REF_NAME is required}"
+: "${GITHUB_WORKFLOW:?GITHUB_WORKFLOW is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+
+case "$GITHUB_REF" in
+  refs/tags/v*) ;;
+  *)
+    echo "proof-required-release: FAIL: expected refs/tags/v*, got $GITHUB_REF" >&2
+    exit 1
+    ;;
+esac
+
+CHECKED_OUT_SHA="$(git rev-parse HEAD)"
+if [[ "$CHECKED_OUT_SHA" != "$GITHUB_SHA" ]]; then
+  echo "proof-required-release: FAIL: checkout $CHECKED_OUT_SHA != event $GITHUB_SHA" >&2
+  exit 1
+fi
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "proof-required-release: FAIL: tracked working tree is dirty" >&2
+  exit 1
+fi
+
+PROOF_ROOT=".build/typed-contract-proof"
+TOOLCHAIN_ROOT=".build/proof-release-toolchain"
+RELEASE_ROOT=".build/proof-required-release"
+RUNTIME=".build/selfhost/arukellt-s2-runtime.wasm"
+PAYLOAD="$RELEASE_ROOT/arukellt-s2-runtime.wasm"
+PROVENANCE="$RELEASE_ROOT/release-provenance.json"
+PAYLOAD_MANIFEST="$RELEASE_ROOT/release-payload-manifest.json"
+AUTHORIZATION="$RELEASE_ROOT/release-authorization.json"
+POLICY="$PROOF_ROOT/release-policy.json"
+BOUNDARY_REGISTRY="release/boundary-registry.json"
+BOUNDARY_REGISTRY_RECEIPT=".build/proof/boundary-registry-validation.json"
+
+rm -rf "$TOOLCHAIN_ROOT" "$RELEASE_ROOT"
+mkdir -p "$PROOF_ROOT" "$TOOLCHAIN_ROOT" "$RELEASE_ROOT" .build/proof
+
+# The major-boundary inventory is pinned to immutable commits and independently
+# revalidated before any local architecture evidence or solver process runs.
+python3 scripts/check/check-boundary-registry.py \
+  --registry "$BOUNDARY_REGISTRY" \
+  --repository "$GITHUB_REPOSITORY" \
+  --receipt-output "$BOUNDARY_REGISTRY_RECEIPT"
+python3 scripts/check/check-boundary-registry-receipt.py \
+  --registry "$BOUNDARY_REGISTRY" \
+  --receipt "$BOUNDARY_REGISTRY_RECEIPT" \
+  --repository "$GITHUB_REPOSITORY"
+
+# Architecture evidence must be generated from this exact checkout.
+python3 scripts/check/check-backend-name-lookup-audit.py
+python3 scripts/check/check-backend-typeid-first.py
+python3 scripts/gen/write-backend-typeid-layout-receipt.py
+python3 scripts/check/check-gc-hint-translation-validation.py
+python3 scripts/gen/write-mir-opt-translation-registry.py
+python3 scripts/check/check-corehir-body-boundary.py
+python3 scripts/gen/write-corehir-body-boundary-receipt.py
+
+python3 - <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "scripts")
+from selfhost.checks import rebuild_current_s2
+
+path, error, elapsed = rebuild_current_s2(Path.cwd(), force=True)
+if path is None:
+    raise SystemExit(error or "stage-2 build failed")
+expected = Path(".build/selfhost/arukellt-s2-runtime.wasm").resolve()
+if path.resolve() != expected:
+    raise SystemExit(f"unexpected stage-2 runtime path: {path}")
+print(f"proof-release-s2: PASS: path={path} elapsed={elapsed:.3f}s")
+PY
+
+test -s "$RUNTIME"
+ARUKELLT_SELFHOST_WASM="$RUNTIME" \
+  python3 scripts/check/check-typed-contract-emission.py
+
+python3 scripts/gen/convert-typed-corehir.py \
+  --input "$PROOF_ROOT/typed-corehir.json" \
+  --output "$PROOF_ROOT/verified-core-machine.json"
+python3 scripts/gen/normalize-source-contract-profile.py \
+  --input "$PROOF_ROOT/verified-core-machine.json" \
+  --output "$PROOF_ROOT/verified-core.json"
+python3 scripts/gen/write-smt-vcs.py \
+  --subject "$PROOF_ROOT/verified-core.json" \
+  --output "$PROOF_ROOT/verified-core-vcs.smt2"
+
+cp "$RUNTIME" "$PAYLOAD"
+python3 scripts/gen/write-release-provenance.py \
+  --repository "$GITHUB_REPOSITORY" \
+  --commit "$GITHUB_SHA" \
+  --ref-type tag \
+  --ref-name "$GITHUB_REF_NAME" \
+  --workflow "$GITHUB_WORKFLOW" \
+  --run-id "$GITHUB_RUN_ID" \
+  --output "$PROVENANCE"
+python3 scripts/gen/write-release-payload-manifest.py \
+  --payload "arukellt-wasm=$PAYLOAD" \
+  --output "$PAYLOAD_MANIFEST"
+
+python3 scripts/gen/write-source-proof-binding.py \
+  --source tests/verified-core/contract_identity.ark \
+  --producer-executable "$RUNTIME" \
+  --typed-corehir "$PROOF_ROOT/typed-corehir.json" \
+  --verified-core-machine "$PROOF_ROOT/verified-core-machine.json" \
+  --verified-core-normalized "$PROOF_ROOT/verified-core.json" \
+  --solver-input "$PROOF_ROOT/verified-core-vcs.smt2" \
+  --boundary-registry "$BOUNDARY_REGISTRY" \
+  --boundary-registry-validation-receipt "$BOUNDARY_REGISTRY_RECEIPT" \
+  --backend-typeid-layout-receipt .build/proof/backend-typeid-layout.json \
+  --optimizer-translation-registry .build/proof/mir-opt-translation-registry.json \
+  --corehir-body-boundary-receipt .build/proof/corehir-body-boundary.json \
+  --release-provenance "$PROVENANCE" \
+  --release-payload-manifest "$PAYLOAD_MANIFEST" \
+  --output "$PROOF_ROOT/source-proof-binding.json"
+
+Z3_BIN="${Z3_BIN:-$(command -v z3)}"
+python3 scripts/gen/prepare-proof-release-toolchain.py \
+  --runtime "$RUNTIME" \
+  --source-binding "$PROOF_ROOT/source-proof-binding.json" \
+  --output-dir "$TOOLCHAIN_ROOT" \
+  --toolchain-output "$TOOLCHAIN_ROOT/toolchain.json" \
+  --z3 "$Z3_BIN"
+
+python3 scripts/run/run-proof-solver.py \
+  --subject "$PROOF_ROOT/verified-core.json" \
+  --solver-input "$PROOF_ROOT/verified-core-vcs.smt2" \
+  --toolchain "$TOOLCHAIN_ROOT/toolchain.json" \
+  --solver-output "$PROOF_ROOT/solver-output.txt" \
+  --trust-manifest-output "$PROOF_ROOT/trust-manifest.json" \
+  --proof-receipt-output "$PROOF_ROOT/proof-receipt.json" \
+  --solver-result-output "$PROOF_ROOT/solver-result.json"
+
+python3 scripts/gen/write-proof-required-release-policy.py --output "$POLICY"
+python3 scripts/check/check-proof-required-release.py \
+  "$POLICY" \
+  --source-binding "$PROOF_ROOT/source-proof-binding.json" \
+  --source tests/verified-core/contract_identity.ark \
+  --producer-executable "$RUNTIME" \
+  --typed-corehir "$PROOF_ROOT/typed-corehir.json" \
+  --verified-core-machine "$PROOF_ROOT/verified-core-machine.json" \
+  --verified-core-normalized "$PROOF_ROOT/verified-core.json" \
+  --solver-input "$PROOF_ROOT/verified-core-vcs.smt2" \
+  --boundary-registry "$BOUNDARY_REGISTRY" \
+  --boundary-registry-validation-receipt "$BOUNDARY_REGISTRY_RECEIPT" \
+  --backend-typeid-layout-receipt .build/proof/backend-typeid-layout.json \
+  --optimizer-translation-registry .build/proof/mir-opt-translation-registry.json \
+  --corehir-body-boundary-receipt .build/proof/corehir-body-boundary.json \
+  --release-provenance "$PROVENANCE" \
+  --release-payload-manifest "$PAYLOAD_MANIFEST" \
+  --release-payload "arukellt-wasm=$PAYLOAD" \
+  --expected-repository "$GITHUB_REPOSITORY" \
+  --expected-commit "$GITHUB_SHA" \
+  --expected-tag "$GITHUB_REF_NAME" \
+  --authorization-output "$AUTHORIZATION"
+
+test -s "$PROOF_ROOT/solver-result.json"
+test -s "$AUTHORIZATION"
+echo "proof-required-release: AUTHORIZED: tag=$GITHUB_REF_NAME commit=$GITHUB_SHA payload=$PAYLOAD"

--- a/scripts/tests/test_boundary_registry.py
+++ b/scripts/tests/test_boundary_registry.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.boundary_registry import (  # noqa: E402
+    BoundaryRegistryError,
+    iter_file_references,
+    load_registry,
+    validate_registry,
+    validate_registry_files,
+)
+from proof.boundary_registry_receipt import (  # noqa: E402
+    BoundaryRegistryReceiptError,
+    create_validation_receipt,
+    validate_validation_receipt,
+)
+
+
+class FakeSource:
+    def __init__(self, files: dict[tuple[str, str], bytes]) -> None:
+        self.files = files
+
+    def fetch(self, repository: str, commit: str, path: str) -> bytes:
+        del repository
+        try:
+            return self.files[(commit, path)]
+        except KeyError as exc:
+            raise BoundaryRegistryError(f"missing fake file: {commit}:{path}") from exc
+
+
+class BoundaryRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry_path = ROOT / "release" / "boundary-registry.json"
+        self.registry = load_registry(self.registry_path)
+        token_sets: dict[tuple[str, str], set[str]] = {}
+        for _, ref in iter_file_references(self.registry):
+            key = (ref["commit"], ref["path"])
+            token_sets.setdefault(key, set()).update(ref["required_tokens"])
+        self.files = {
+            key: ("\n".join(sorted(tokens)) + "\n").encode("utf-8")
+            for key, tokens in token_sets.items()
+        }
+        self.source = FakeSource(self.files)
+
+    def test_complete_registry_validates_all_seven_boundaries(self) -> None:
+        fetched = validate_registry_files(self.registry, self.source)
+        self.assertEqual(set(self.registry["required_boundaries"]), {
+            "typed-corehir",
+            "corehir-body",
+            "verified-core",
+            "mir-optimizer",
+            "backend-layout",
+            "solver-result",
+            "release-authorization",
+        })
+        self.assertGreaterEqual(len(fetched), 28)
+
+    def test_missing_major_boundary_is_rejected(self) -> None:
+        document = copy.deepcopy(self.registry)
+        document["boundaries"] = document["boundaries"][:-1]
+        with self.assertRaisesRegex(BoundaryRegistryError, "boundary count mismatch"):
+            validate_registry(document)
+
+    def test_short_commit_is_rejected(self) -> None:
+        document = copy.deepcopy(self.registry)
+        document["boundaries"][0]["producer"]["commit"] = "c6b502c"
+        with self.assertRaisesRegex(BoundaryRegistryError, "full lowercase commit SHA"):
+            validate_registry(document)
+
+    def test_branch_name_is_rejected_as_commit(self) -> None:
+        document = copy.deepcopy(self.registry)
+        document["boundaries"][0]["producer"]["commit"] = "agent/typed-verified-core-emitter"
+        with self.assertRaisesRegex(BoundaryRegistryError, "full lowercase commit SHA"):
+            validate_registry(document)
+
+    def test_producer_cannot_be_its_own_validator(self) -> None:
+        document = copy.deepcopy(self.registry)
+        document["boundaries"][0]["validator"] = copy.deepcopy(
+            document["boundaries"][0]["producer"]
+        )
+        with self.assertRaisesRegex(BoundaryRegistryError, "independent files"):
+            validate_registry(document)
+
+    def test_missing_required_token_is_rejected(self) -> None:
+        document = copy.deepcopy(self.registry)
+        ref = document["boundaries"][0]["producer"]
+        files = dict(self.files)
+        files[(ref["commit"], ref["path"])] = b"unrelated content\n"
+        with self.assertRaisesRegex(BoundaryRegistryError, "required token missing"):
+            validate_registry_files(document, FakeSource(files))
+
+    def test_receipt_binds_registry_and_remote_files(self) -> None:
+        receipt = create_validation_receipt(self.registry_path, self.source)
+        validated = validate_validation_receipt(
+            receipt,
+            registry_path=self.registry_path,
+            source=self.source,
+        )
+        self.assertEqual(validated["status"], "validated")
+        self.assertEqual(validated["boundary_count"], 7)
+
+    def test_stale_remote_file_invalidates_receipt(self) -> None:
+        receipt = create_validation_receipt(self.registry_path, self.source)
+        files = dict(self.files)
+        key = next(iter(files))
+        files[key] += b"changed\n"
+        with self.assertRaisesRegex(BoundaryRegistryReceiptError, "stale receipt"):
+            validate_validation_receipt(
+                receipt,
+                registry_path=self.registry_path,
+                source=FakeSource(files),
+            )
+
+    def test_duplicate_receipt_file_is_rejected(self) -> None:
+        receipt = create_validation_receipt(self.registry_path, self.source)
+        receipt["files"].append(copy.deepcopy(receipt["files"][0]))
+        with self.assertRaisesRegex(BoundaryRegistryReceiptError, "duplicate receipt file"):
+            validate_validation_receipt(receipt, registry_path=self.registry_path)
+
+    def test_registry_digest_substitution_is_rejected(self) -> None:
+        receipt = create_validation_receipt(self.registry_path, self.source)
+        with tempfile.TemporaryDirectory() as directory:
+            changed = Path(directory) / "registry.json"
+            document = copy.deepcopy(self.registry)
+            document["boundaries"][0]["failure_action"] += " changed"
+            changed.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(BoundaryRegistryReceiptError, "does not bind"):
+                validate_validation_receipt(receipt, registry_path=changed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_proof_required_release_gate.py
+++ b/scripts/tests/test_proof_required_release_gate.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.common import sha256_file  # noqa: E402
+from proof.release_gate import (  # noqa: E402
+    ProofRequiredReleaseError,
+    validate_proof_required_release,
+)
+from proof.release_payload import (  # noqa: E402
+    ReleasePayloadError,
+    create_release_payload_manifest,
+)
+from proof.release_provenance import (  # noqa: E402
+    ReleaseProvenanceError,
+    create_release_provenance,
+)
+from proof.source_proof_binding import (  # noqa: E402
+    SourceProofBindingError,
+    write_binding,
+)
+
+
+class ProofRequiredReleaseGateTests(unittest.TestCase):
+    REPOSITORY = "wogikaze/arukellt"
+    COMMIT = "1" * 40
+    TAG = "v1.2.3"
+
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.payload = self.root / "arukellt.wasm"
+        self.payload.write_bytes(b"release-payload\n")
+        self.payloads = {"arukellt-wasm": self.payload}
+
+        self.provenance_path = self.root / "release-provenance.json"
+        self.provenance_path.write_text(
+            json.dumps(
+                create_release_provenance(
+                    repository=self.REPOSITORY,
+                    commit_sha=self.COMMIT,
+                    ref_type="tag",
+                    ref_name=self.TAG,
+                    workflow="Proof required release",
+                    run_id="123",
+                )
+            ),
+            encoding="utf-8",
+        )
+        self.payload_manifest_path = self.root / "release-payload-manifest.json"
+        self.payload_manifest_path.write_text(
+            json.dumps(create_release_payload_manifest(self.payloads)),
+            encoding="utf-8",
+        )
+
+        self.paths = {
+            "source": self.root / "source.ark",
+            "producer_executable": self.root / "compiler.wasm",
+            "typed_corehir": self.root / "typed-corehir.json",
+            "verified_core_machine": self.root / "verified-core-machine.json",
+            "verified_core_normalized": self.root / "verified-core.json",
+            "solver_input": self.root / "vcs.smt2",
+            "boundary_registry": self.root / "boundary-registry.json",
+            "boundary_registry_validation_receipt": self.root / "boundary-registry-validation.json",
+            "backend_typeid_layout_receipt": self.root / "backend-typeid-layout.json",
+            "optimizer_translation_registry": self.root / "mir-opt-registry.json",
+            "corehir_body_boundary_receipt": self.root / "body-boundary.json",
+            "release_provenance": self.provenance_path,
+            "release_payload_manifest": self.payload_manifest_path,
+        }
+        for index, (name, path) in enumerate(self.paths.items()):
+            if name in {"release_provenance", "release_payload_manifest"}:
+                continue
+            if name == "producer_executable":
+                path.write_bytes(self.payload.read_bytes())
+            else:
+                path.write_bytes(f"artifact-{index}\n".encode())
+
+        self.binding_path = self.root / "source-proof-binding.json"
+        write_binding(self.paths, self.binding_path)
+        self.manifest_path = self.root / "trust-manifest.json"
+        self.receipt_path = self.root / "proof-receipt.json"
+        self.solver_output_path = self.root / "solver-output.txt"
+        self.receipt_path.write_text("{}\n", encoding="utf-8")
+        self.solver_output_path.write_text("unsat\n", encoding="utf-8")
+        self.policy_path = self.root / "release-policy.json"
+        self.write_manifest()
+        self.policy_path.write_text(
+            json.dumps(
+                {
+                    "schema": "arukellt-proof-release-policy",
+                    "schema_version": 1,
+                    "mode": "proof-required",
+                    "hard_gates": {},
+                    "artifacts": [
+                        {
+                            "subject": self.paths["verified_core_normalized"].name,
+                            "trust_manifest": self.manifest_path.name,
+                            "receipt": self.receipt_path.name,
+                            "solver_output": self.solver_output_path.name,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def write_manifest(
+        self,
+        *,
+        binding_digest: str | None = None,
+        subject_digest: str | None = None,
+        binding_version: str = "4",
+    ) -> None:
+        self.manifest_path.write_text(
+            json.dumps(
+                {
+                    "subject": {
+                        "sha256": subject_digest
+                        or sha256_file(self.paths["verified_core_normalized"]),
+                    },
+                    "producer": {
+                        "executable_sha256": sha256_file(
+                            self.paths["producer_executable"]
+                        )
+                    },
+                    "trusted_components": [
+                        {
+                            "role": "source-artifact-binding",
+                            "version": binding_version,
+                            "artifact_sha256": binding_digest
+                            or sha256_file(self.binding_path),
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def validate(self) -> tuple[str, int]:
+        with patch(
+            "proof.release_gate.check_release_policy",
+            return_value=("proof-required", 1),
+        ), patch(
+            "proof.release_gate.validate_trust_manifest",
+            side_effect=lambda value: value,
+        ):
+            return validate_proof_required_release(
+                self.policy_path,
+                self.binding_path,
+                self.paths,
+                expected_repository=self.REPOSITORY,
+                expected_commit=self.COMMIT,
+                expected_tag=self.TAG,
+                release_payloads=self.payloads,
+            )
+
+    def test_accepts_complete_commit_bound_payload_chain(self) -> None:
+        self.assertEqual(self.validate(), ("proof-required", 1))
+
+    def test_rejects_stale_source_digest(self) -> None:
+        self.paths["source"].write_text("changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(SourceProofBindingError, "source: digest mismatch"):
+            self.validate()
+
+    def test_rejects_stale_boundary_registry(self) -> None:
+        self.paths["boundary_registry"].write_text("substituted\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+            SourceProofBindingError, "boundary_registry: digest mismatch"
+        ):
+            self.validate()
+
+    def test_rejects_stale_boundary_registry_validation_receipt(self) -> None:
+        self.paths["boundary_registry_validation_receipt"].write_text(
+            "substituted\n", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(
+            SourceProofBindingError,
+            "boundary_registry_validation_receipt: digest mismatch",
+        ):
+            self.validate()
+
+    def test_rejects_stale_optimizer_registry(self) -> None:
+        self.paths["optimizer_translation_registry"].write_text(
+            "substituted\n", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(
+            SourceProofBindingError, "optimizer_translation_registry: digest mismatch"
+        ):
+            self.validate()
+
+    def test_rejects_stale_backend_layout_receipt(self) -> None:
+        self.paths["backend_typeid_layout_receipt"].write_text(
+            "substituted\n", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(
+            SourceProofBindingError, "backend_typeid_layout_receipt: digest mismatch"
+        ):
+            self.validate()
+
+    def test_rejects_unbound_source_binding(self) -> None:
+        self.write_manifest(binding_digest="0" * 64)
+        with self.assertRaisesRegex(
+            ProofRequiredReleaseError,
+            "does not bind the supplied source proof binding",
+        ):
+            self.validate()
+
+    def test_rejects_legacy_source_binding_version(self) -> None:
+        self.write_manifest(binding_version="3")
+        with self.assertRaisesRegex(ProofRequiredReleaseError, "version 4"):
+            self.validate()
+
+    def test_rejects_unbound_compiler_executable(self) -> None:
+        manifest = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        manifest["producer"]["executable_sha256"] = "0" * 64
+        self.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        with self.assertRaisesRegex(
+            ProofRequiredReleaseError,
+            "producer does not bind the supplied compiler executable",
+        ):
+            self.validate()
+
+    def test_rejects_unrelated_proof_subject(self) -> None:
+        self.write_manifest(subject_digest="0" * 64)
+        with self.assertRaisesRegex(ProofRequiredReleaseError, "normalized VerifiedCore"):
+            self.validate()
+
+    def test_rejects_receipt_replay_on_different_commit(self) -> None:
+        with patch(
+            "proof.release_gate.check_release_policy",
+            return_value=("proof-required", 1),
+        ), patch(
+            "proof.release_gate.validate_trust_manifest",
+            side_effect=lambda value: value,
+        ):
+            with self.assertRaisesRegex(ReleaseProvenanceError, "commit mismatch"):
+                validate_proof_required_release(
+                    self.policy_path,
+                    self.binding_path,
+                    self.paths,
+                    expected_repository=self.REPOSITORY,
+                    expected_commit="2" * 40,
+                    expected_tag=self.TAG,
+                    release_payloads=self.payloads,
+                )
+
+    def test_rejects_receipt_replay_on_different_tag(self) -> None:
+        with patch(
+            "proof.release_gate.check_release_policy",
+            return_value=("proof-required", 1),
+        ), patch(
+            "proof.release_gate.validate_trust_manifest",
+            side_effect=lambda value: value,
+        ):
+            with self.assertRaisesRegex(ReleaseProvenanceError, "tag mismatch"):
+                validate_proof_required_release(
+                    self.policy_path,
+                    self.binding_path,
+                    self.paths,
+                    expected_repository=self.REPOSITORY,
+                    expected_commit=self.COMMIT,
+                    expected_tag="v9.9.9",
+                    release_payloads=self.payloads,
+                )
+
+    def test_rejects_payload_substitution_after_proof(self) -> None:
+        self.payload.write_bytes(b"different-release-payload\n")
+        with self.assertRaisesRegex(ReleasePayloadError, "payload digest mismatch"):
+            self.validate()
+
+    def test_rejects_manifest_valid_but_unproved_payload(self) -> None:
+        self.payload.write_bytes(b"different-release-payload\n")
+        self.payload_manifest_path.write_text(
+            json.dumps(create_release_payload_manifest(self.payloads)),
+            encoding="utf-8",
+        )
+        write_binding(self.paths, self.binding_path)
+        self.write_manifest()
+        with self.assertRaisesRegex(
+            ProofRequiredReleaseError,
+            "not the proved producer executable",
+        ):
+            self.validate()
+
+    def test_rejects_proof_optional_policy(self) -> None:
+        with patch(
+            "proof.release_gate.check_release_policy",
+            return_value=("proof-optional", 1),
+        ):
+            with self.assertRaisesRegex(
+                ProofRequiredReleaseError, "must be proof-required"
+            ):
+                validate_proof_required_release(
+                    self.policy_path,
+                    self.binding_path,
+                    self.paths,
+                    expected_repository=self.REPOSITORY,
+                    expected_commit=self.COMMIT,
+                    expected_tag=self.TAG,
+                    release_payloads=self.payloads,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_authorization.py
+++ b/scripts/tests/test_release_authorization.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from proof.release_authorization import (  # noqa: E402
+    ReleaseAuthorizationError,
+    create_release_authorization,
+    validate_bound_release_authorization,
+    write_release_authorization,
+)
+
+
+class ReleaseAuthorizationTests(unittest.TestCase):
+    def test_authorization_binds_complete_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            files = {
+                name: root / name
+                for name in (
+                    "policy.json",
+                    "binding.json",
+                    "manifest.json",
+                    "receipt.json",
+                    "payload.json",
+                )
+            }
+            for index, path in enumerate(files.values()):
+                path.write_text(f"artifact-{index}\n", encoding="utf-8")
+            authorization_path = root / "authorization.json"
+            document = create_release_authorization(
+                repository="wogikaze/arukellt",
+                commit_sha="a" * 40,
+                tag="v1.0.0",
+                policy_path=files["policy.json"],
+                source_binding_path=files["binding.json"],
+                trust_manifest_path=files["manifest.json"],
+                proof_receipt_path=files["receipt.json"],
+                payload_manifest_path=files["payload.json"],
+            )
+            write_release_authorization(document, authorization_path)
+            validate_bound_release_authorization(
+                authorization_path,
+                repository="wogikaze/arukellt",
+                commit_sha="a" * 40,
+                tag="v1.0.0",
+                policy_path=files["policy.json"],
+                source_binding_path=files["binding.json"],
+                trust_manifest_path=files["manifest.json"],
+                proof_receipt_path=files["receipt.json"],
+                payload_manifest_path=files["payload.json"],
+            )
+
+            files["receipt.json"].write_text("substituted\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                ReleaseAuthorizationError, "proof_receipt_sha256 mismatch"
+            ):
+                validate_bound_release_authorization(
+                    authorization_path,
+                    repository="wogikaze/arukellt",
+                    commit_sha="a" * 40,
+                    tag="v1.0.0",
+                    policy_path=files["policy.json"],
+                    source_binding_path=files["binding.json"],
+                    trust_manifest_path=files["manifest.json"],
+                    proof_receipt_path=files["receipt.json"],
+                    payload_manifest_path=files["payload.json"],
+                )
+
+    def test_authorization_rejects_different_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            files = [root / f"f{index}" for index in range(5)]
+            for path in files:
+                path.write_text("x", encoding="utf-8")
+            authorization_path = root / "authorization.json"
+            write_release_authorization(
+                create_release_authorization(
+                    repository="wogikaze/arukellt",
+                    commit_sha="b" * 40,
+                    tag="v1.0.0",
+                    policy_path=files[0],
+                    source_binding_path=files[1],
+                    trust_manifest_path=files[2],
+                    proof_receipt_path=files[3],
+                    payload_manifest_path=files[4],
+                ),
+                authorization_path,
+            )
+            with self.assertRaisesRegex(ReleaseAuthorizationError, "tag mismatch"):
+                validate_bound_release_authorization(
+                    authorization_path,
+                    repository="wogikaze/arukellt",
+                    commit_sha="b" * 40,
+                    tag="v2.0.0",
+                    policy_path=files[0],
+                    source_binding_path=files[1],
+                    trust_manifest_path=files[2],
+                    proof_receipt_path=files[3],
+                    payload_manifest_path=files[4],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_source_proof_binding.py
+++ b/scripts/tests/test_source_proof_binding.py
@@ -13,6 +13,7 @@ if str(SCRIPTS) not in sys.path:
 
 from proof.source_proof_binding import (  # noqa: E402
     REQUIRED_ARTIFACTS,
+    VERSION,
     SourceProofBindingError,
     validate_binding,
     write_binding,
@@ -32,11 +33,34 @@ class SourceProofBindingTests(unittest.TestCase):
             written = write_binding(paths, output)
             loaded = json.loads(output.read_text())
             self.assertEqual(written, loaded)
+            self.assertEqual(loaded["schema_version"], 4)
             validate_binding(loaded, paths)
 
             paths["typed_corehir"].write_bytes(b"changed")
             with self.assertRaisesRegex(SourceProofBindingError, "digest mismatch"):
                 validate_binding(loaded, paths)
+
+    def test_v4_requires_registry_and_validation_receipt(self) -> None:
+        self.assertEqual(VERSION, 4)
+        self.assertIn("boundary_registry", REQUIRED_ARTIFACTS)
+        self.assertIn("boundary_registry_validation_receipt", REQUIRED_ARTIFACTS)
+
+    def test_stale_registry_receipt_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            paths: dict[str, Path] = {}
+            for index, name in enumerate(REQUIRED_ARTIFACTS):
+                path = root / f"{name}.bin"
+                path.write_bytes(f"artifact-{index}".encode())
+                paths[name] = path
+            output = root / "binding.json"
+            written = write_binding(paths, output)
+            paths["boundary_registry_validation_receipt"].write_bytes(b"changed")
+            with self.assertRaisesRegex(
+                SourceProofBindingError,
+                "boundary_registry_validation_receipt: digest mismatch",
+            ):
+                validate_binding(written, paths)
 
     def test_binding_requires_complete_artifact_set(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
Supersedes #34 and #36 for stack integration.

This clean final integration adds the proof-required release authorization chain and the versioned major-boundary registry on top of the already-integrated compiler, optimizer, backend, typed VerifiedCore, SolverResult, source-contract, and frozen-body boundaries.

Key integration properties:
- all seven hard gates are true in one policy
- source proof binding v4 includes the registry and independent validation receipt
- tag release binds repository, commit, tag, source chain, architecture evidence, TrustManifest, ProofReceipt, and final payload
- release authorization is independently checked before publishing
- every solver workflow emits SolverResult, independently checks it, and generates/revalidates the solver-trust boundary receipt
- the release toolchain uses converter v2, semantic VerifiedCore validation, typed SMT admission, and SolverResult validation
- old contract-converter and raw solver paths are not restored

No CI result is claimed.