### PR TITLE
fix(wasm32): emit i32 for linear String/ref signatures

### DIFF
--- a/scripts/tests/test_wasm32_i32_to_string.py
+++ b/scripts/tests/test_wasm32_i32_to_string.py
@@ -1,0 +1,71 @@
+"""wasm32: i32.to_string must emit a valid linear module, not (ref i32)."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = "tests/fixtures/stdlib_io/i32_to_string.ark"
+
+
+class Wasm32I32ToStringTests(unittest.TestCase):
+    def test_wasm32_wasi_p1_compiles_validates_and_runs(self):
+        if not (ROOT / ".build/selfhost/arukellt-s2-runtime.wasm").is_file():
+            self.skipTest("s2 runtime wasm is not built")
+        wasm_tools = shutil.which("wasm-tools")
+        if wasm_tools is None:
+            self.skipTest("wasm-tools is required")
+
+        runtime = ROOT / ".build/selfhost/arukellt-s2-runtime.wasm"
+        output = ROOT / ".build/tests/i32_to_string_wasm32.wasm"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        env = os.environ.copy()
+        env["ARUKELLT_SELFHOST_WASM"] = str(runtime)
+        compile_result = subprocess.run(
+            [
+                str(ROOT / "scripts/run/arukellt-selfhost.sh"),
+                "compile",
+                FIXTURE,
+                "--target",
+                "wasm32",
+                "--wasi-version",
+                "wasi-p1",
+                "-o",
+                str(output.relative_to(ROOT)),
+            ],
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            compile_result.returncode,
+            0,
+            compile_result.stdout + compile_result.stderr,
+        )
+        validate = subprocess.run(
+            [wasm_tools, "validate", str(output)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(validate.returncode, 0, validate.stdout + validate.stderr)
+
+        run = subprocess.run(
+            ["wasmtime", "run", str(output)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(run.returncode, 0, run.stdout + run.stderr)
+        self.assertEqual(run.stdout.strip(), "0\n42\n-100")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/compiler/wasm/sections_type_plan.ark
+++ b/src/compiler/wasm/sections_type_plan.ark
@@ -1,3 +1,5 @@
+use mir::value_types
+
 pub struct TypeSectionPlan {
     host_type_map: Vec<i32>,
     fn_type_map: Vec<i32>,
@@ -268,11 +270,14 @@ fn val_type_to_sig(vt: i32) -> String {
 }
 
 fn val_type_to_target_sig(vt: i32, is_gc_target: bool, memory64: bool) -> String {
-    if vt == 5 && !is_gc_target {
+    // Linear wasm32 stores String/Vec as i32 pointers. Emitting the GC
+    // "ref"/"gcref" sigs with an empty TypeSectionPlan map writes
+    // `ref.null` + leb128(-1) = 0x63 0x7f, which is not a valid valtype.
+    if !is_gc_target && (vt == value_types::VT_REF() || vt == value_types::VT_GC_REF()) {
         return "i32"
     }
     // Typed funcref stays a reference type under Memory64 (not an i64 index).
-    if vt == 8 {
+    if vt == value_types::VT_FUNCREF() {
         return "fnref"
     }
     // Memory64 (wasm32-gc default): widen former i32 Wasm values to i64.

--- a/src/compiler/wasm/sections_types_emit.ark
+++ b/src/compiler/wasm/sections_types_emit.ark
@@ -12,6 +12,15 @@ fn gc_fixed_type_index(gc_fixed_type_map: Vec<i32>, slot: i32) -> i32 {
     get_unchecked(gc_fixed_type_map, slot)
 }
 
+fn emit_nullable_type_or_i32(type_sec: WasmWriter, type_idx: i32) {
+    if type_idx < 0 {
+        writer_core::emit_byte(type_sec, constants::WASM_I32())
+        return
+    }
+    writer_core::emit_byte(type_sec, constants::WASM_REF_NULL())
+    writer_core::emit_leb128_s(type_sec, type_idx)
+}
+
 fn emit_canon_type_entries(type_sec: WasmWriter, canon_types: Vec<String>, gc_fixed_type_map: Vec<i32>, gc_struct_type_map: Vec<i32>) {
     for cti2 in 0..len(canon_types) {
         let csig = get_unchecked(canon_types, cti2)
@@ -268,13 +277,11 @@ fn emit_sig_val_type(
     }
     if starts_with(clone(sig), String_from("gcref")) {
         let slot = sections_types_sig_parse::parse_gcref_offset(sig)
-        writer_core::emit_byte(type_sec, constants::WASM_REF_NULL())
-        writer_core::emit_leb128_s(type_sec, gc_fixed_type_index(gc_fixed_type_map, slot))
+        emit_nullable_type_or_i32(type_sec, gc_fixed_type_index(gc_fixed_type_map, slot))
         return
     }
     if eq(clone(sig), "ref") {
-        writer_core::emit_byte(type_sec, constants::WASM_REF_NULL())
-        writer_core::emit_leb128_s(type_sec, gc_fixed_type_index(gc_fixed_type_map, 0))
+        emit_nullable_type_or_i32(type_sec, gc_fixed_type_index(gc_fixed_type_map, 0))
         return
     }
     writer_core::emit_byte(type_sec, sections_type_plan::sig_to_wasm_type(sig))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked wasm32 linear String/ref fix. **Merged into the rollout branch** (`59789e9d` is now on `cursor/wasm32-gc-primary-rollout-41a0`).

Isolated `build-compiler` EXIT 0 (262.6s). `--target wasm32 --wasi-p1`:
- `i32_to_string.ark` validates and prints `0` / `42` / `-100`
- `fib.ark` validates and prints `9227465`
- `hello.ark` still validates
- wasm32-gc `i32_to_string` / `fib` still validate and run; `name=0 fallback=0`

`python3 scripts/tests/test_wasm32_i32_to_string.py` OK.

Official pin is not refreshed from this commit (verify full still using `5abf9573`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-519b4bd0-f055-42fc-9a1f-0e86f4e941a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-519b4bd0-f055-42fc-9a1f-0e86f4e941a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

