### PR TITLE
fix(wasm32): leftover linear bench type-mismatch (nested get / hashmap new / closure)

### DIFF
--- a/src/compiler/wasm/inst_dispatch_const.ark
+++ b/src/compiler/wasm/inst_dispatch_const.ark
@@ -61,6 +61,18 @@ fn try_emit_ref_func_inst(
         }
         i = i + 1
     }
+    // Linear ABI stores table indices in i32 locals. `ref.func` produces
+    // `(ref $sig)` and fails validate when the dest is i32 (closure_map).
+    if !emit_target::is_gc_target(ctx_record::SelfEmitCtx_target(ctx)) {
+        writer_core::emit_byte(w, opcodes::OP_I32_CONST())
+        if found == 0 {
+            writer_core::emit_leb128_s(w, 0)
+        } else {
+            writer_core::emit_leb128_s(w, mir_fn_idx)
+        }
+        inst_store::emit_store_result_if_needed(w, inst, next_op, next_arg0, next_arg1, next2_op, true)
+        return true
+    }
     // Typed funcref: emit ref.func with the module function index. Active
     // table elem segments already declare referenced functions (#831 / ADR-033).
     writer_core::emit_byte(w, opcodes::OP_REF_FUNC())

--- a/src/compiler/wasm/inst_dispatch_struct.ark
+++ b/src/compiler/wasm/inst_dispatch_struct.ark
@@ -21,8 +21,25 @@ fn try_emit_struct_inst(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, prev_op:
     false
 }
 
+fn next_is_nested_struct_get(next_op: i32, next_arg0: i32) -> bool {
+    next_op == opcodes::MIR_STRUCT_GET() && next_arg0 < 0
+}
+
+fn emit_set_and_reload(w: WasmWriter, dest: i32) {
+    writer_core::emit_byte(w, wasm_opcodes::OP_LOCAL_SET())
+    writer_core::emit_leb128_u(w, dest)
+    writer_core::emit_byte(w, wasm_opcodes::OP_LOCAL_GET())
+    writer_core::emit_leb128_u(w, dest)
+}
+
 fn emit_gc_ref_struct_get_store(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, next_op: i32, next_arg0: i32, next_arg1: i32, next2_op: i32) {
     let dest = inst_accessors_operands::MirInst_dest(inst)
+    // Nested `r.max.x` / `fields[i].name`: linear STRUCT_GET loads the base
+    // from the stack. A SET of the intermediate pointer empties it.
+    if dest >= 0 && next_is_nested_struct_get(next_op, next_arg0) {
+        emit_set_and_reload(w, dest)
+        return
+    }
     let vt = inst_accessors_shape::MirInst_val_type(inst)
     let is_ref = vt == value_types::VT_GC_REF() || vt == value_types::VT_REF()
     if dest >= 0 && is_ref && emit_target::is_gc_target(ctx_record::SelfEmitCtx_target(ctx)) {
@@ -93,6 +110,11 @@ fn try_emit_array_inst(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, next_op: 
     }
     if op == opcodes::MIR_ARRAY_GET() {
         inst_array::emit_array_get(w, inst, ctx)
+        let dest = inst_accessors_operands::MirInst_dest(inst)
+        if dest >= 0 && next_is_nested_struct_get(next_op, next_arg0) {
+            emit_set_and_reload(w, dest)
+            return true
+        }
         inst_dispatch_result::emit_result_if_needed(w, inst, next_op, next_arg0, next_arg1, next2_op)
         return true
     }

--- a/src/compiler/wasm/inst_struct_record.ark
+++ b/src/compiler/wasm/inst_struct_record.ark
@@ -136,6 +136,18 @@ fn emit_struct_new(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, prev_op: i32)
     helpers_core::emit_heap_set(w)
 }
 
+fn emit_linear_struct_get_base(w: WasmWriter, inst: MirInst, prev_op: i32, prev_arg0: i32) {
+    let base_local = inst_accessors_operands::MirInst_arg0(inst)
+    if base_local < 0 {
+        return
+    }
+    if prev_op == mir::opcodes::MIR_LOCAL_GET() && prev_arg0 == base_local {
+        return
+    }
+    writer_core::emit_byte(w, opcodes::OP_LOCAL_GET())
+    writer_core::emit_leb128_u(w, base_local)
+}
+
 fn emit_struct_get(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, prev_op: i32, prev_arg0: i32) {
     if emit_target::is_gc_target(ctx_record::SelfEmitCtx_target(ctx)) {
         let byte_offset = inst_accessors_literals::MirInst_int_val(inst)
@@ -176,6 +188,10 @@ fn emit_struct_get(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, prev_op: i32,
     }
     return
 }
+// Linear STRUCT_GET never had a base load. After a nested field SET
+// (`r.max` then `.x`) the pointer is only in dest, so i32.load saw
+// an empty stack (rect_area / toml_find_field_index / data_pipeline).
+emit_linear_struct_get_base(w, inst, prev_op, prev_arg0)
 if inst_accessors_literals::MirInst_int_val(inst) > 0 {
     writer_core::emit_byte(w, opcodes::OP_I32_CONST())
     writer_core::emit_leb128_s(w, inst_accessors_literals::MirInst_int_val(inst))

--- a/src/compiler/wasm/intrinsic_hashmap_str_new.ark
+++ b/src/compiler/wasm/intrinsic_hashmap_str_new.ark
@@ -9,12 +9,21 @@ use wasm::ctx_gc_type_vec_ref
 use wasm::inst_ctx
 use wasm::inst_store
 use wasm::function_indices
+use wasm::intrinsic_vec_new_layout
+use wasm::intrinsic_hashmap_str_lm_helpers
 
-fn emit_hm_si_new(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, next_op: i32, next_arg0: i32, next_arg1: i32, next2_op: i32, wit_import_count: i32) {
-    if emit_target::is_gc_target(ctx_record::SelfEmitCtx_target(ctx)) {
-        emit_hm_si_new_gc(w, ctx)
-    } else {
-        let fn_idx = inst_ctx::resolve_fn_index(ctx, "hashmap_new")
+// Flat Vec<i32> layout from hashmap_new: [cap, size, keys, values, flags].
+fn lm_hashmap_default_cap() -> i32 {
+    16
+}
+
+fn lm_hashmap_flat_len() -> i32 {
+    2 + lm_hashmap_default_cap() * 3
+}
+
+fn emit_hm_new_linear(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, wit_import_count: i32) {
+    let fn_idx = inst_ctx::resolve_fn_index(ctx, "hashmap_new")
+    if fn_idx >= 0 {
         writer_core::emit_byte(w, opcodes::OP_CALL())
         writer_core::emit_leb128_u(
             w,
@@ -27,6 +36,52 @@ fn emit_hm_si_new(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, next_op: i32, 
                 wit_import_count
             )
         )
+        return
+    }
+    // __hm_*_new call sites DCE hashmap_new; calling the missing index
+    // becomes import `random_get` (expected i32, empty stack).
+    emit_hm_new_linear_inline(w, inst, ctx)
+}
+
+fn emit_hm_new_linear_inline(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx) {
+    let flat_len = lm_hashmap_flat_len()
+    let data_bytes = flat_len * 4
+    intrinsic_vec_new_layout::emit_vec_new_layout(w, data_bytes, data_bytes + 12, inst, ctx)
+    let s_map = ctx_scratch::SelfEmitCtx_scratch_base(ctx)
+    let s_val = ctx_scratch::SelfEmitCtx_scratch_local(ctx, 1)
+    writer_core::emit_byte(w, opcodes::OP_LOCAL_SET())
+    writer_core::emit_leb128_u(w, s_map)
+    writer_core::emit_byte(w, opcodes::OP_LOCAL_GET())
+    writer_core::emit_leb128_u(w, s_map)
+    writer_core::emit_byte(w, opcodes::OP_I32_CONST())
+    writer_core::emit_leb128_s(w, flat_len)
+    writer_core::emit_byte(w, opcodes::OP_I32_STORE())
+    writer_core::emit_byte(w, 2)
+    writer_core::emit_byte(w, 0)
+    writer_core::emit_byte(w, opcodes::OP_LOCAL_GET())
+    writer_core::emit_leb128_u(w, s_map)
+    writer_core::emit_byte(w, opcodes::OP_I32_CONST())
+    writer_core::emit_leb128_s(w, 4)
+    writer_core::emit_byte(w, opcodes::OP_I32_ADD())
+    writer_core::emit_byte(w, opcodes::OP_I32_CONST())
+    writer_core::emit_leb128_s(w, flat_len)
+    writer_core::emit_byte(w, opcodes::OP_I32_STORE())
+    writer_core::emit_byte(w, 2)
+    writer_core::emit_byte(w, 0)
+    writer_core::emit_byte(w, opcodes::OP_I32_CONST())
+    writer_core::emit_leb128_s(w, lm_hashmap_default_cap())
+    writer_core::emit_byte(w, opcodes::OP_LOCAL_SET())
+    writer_core::emit_leb128_u(w, s_val)
+    intrinsic_hashmap_str_lm_helpers::emit_lm_flat_store_const(w, s_map, 0, s_val)
+    writer_core::emit_byte(w, opcodes::OP_LOCAL_GET())
+    writer_core::emit_leb128_u(w, s_map)
+}
+
+fn emit_hm_si_new(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, next_op: i32, next_arg0: i32, next_arg1: i32, next2_op: i32, wit_import_count: i32) {
+    if emit_target::is_gc_target(ctx_record::SelfEmitCtx_target(ctx)) {
+        emit_hm_si_new_gc(w, ctx)
+    } else {
+        emit_hm_new_linear(w, inst, ctx, wit_import_count)
     }
     inst_store::emit_store_result_if_needed(w, inst, next_op, next_arg0, next_arg1, next2_op, true)
 }
@@ -79,19 +134,7 @@ fn emit_hm_is_new(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, next_op: i32, 
     if emit_target::is_gc_target(ctx_record::SelfEmitCtx_target(ctx)) {
         emit_hm_is_new_gc(w, ctx)
     } else {
-        let fn_idx = inst_ctx::resolve_fn_index(ctx, "hashmap_new")
-        writer_core::emit_byte(w, opcodes::OP_CALL())
-        writer_core::emit_leb128_u(
-            w,
-            function_indices::defined_function_index(
-                fn_idx,
-                ctx_record::SelfEmitCtx_target(ctx),
-                ctx_record::SelfEmitCtx_wasi_version(ctx),
-                ctx_record::SelfEmitCtx_needs_runtime_host(ctx),
-                ctx_record::SelfEmitCtx_needs_wasi_http_outgoing(ctx),
-                wit_import_count
-            )
-        )
+        emit_hm_new_linear(w, inst, ctx, wit_import_count)
     }
     inst_store::emit_store_result_if_needed(w, inst, next_op, next_arg0, next_arg1, next2_op, true)
 }
@@ -164,19 +207,7 @@ fn emit_hm_ss_new(w: WasmWriter, inst: MirInst, ctx: SelfEmitCtx, next_op: i32, 
     if emit_target::is_gc_target(ctx_record::SelfEmitCtx_target(ctx)) {
         emit_hm_ss_new_gc(w, ctx)
     } else {
-        let fn_idx = inst_ctx::resolve_fn_index(ctx, "hashmap_new")
-        writer_core::emit_byte(w, opcodes::OP_CALL())
-        writer_core::emit_leb128_u(
-            w,
-            function_indices::defined_function_index(
-                fn_idx,
-                ctx_record::SelfEmitCtx_target(ctx),
-                ctx_record::SelfEmitCtx_wasi_version(ctx),
-                ctx_record::SelfEmitCtx_needs_runtime_host(ctx),
-                ctx_record::SelfEmitCtx_needs_wasi_http_outgoing(ctx),
-                wit_import_count
-            )
-        )
+        emit_hm_new_linear(w, inst, ctx, wit_import_count)
     }
     inst_store::emit_store_result_if_needed(w, inst, next_op, next_arg0, next_arg1, next2_op, true)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
公式 pin `54d01aff` 上の 6f leftover を直す stacked PR。公式 VF 終了まで clock-qmark へ merge しない。PR 47 は Draft のまま。pin-refresh しない。

## Isolated s2 `175fb683`（commit `36dcdbef`）

`build-compiler` EXIT 0。`verify lane` → **LANE:0**。

### 6f quick benches — 20/20 MATCH on both targets

leftover 7 + remaining 13。wasm32-gc はすべて `name=0 fallback=0`。

公式 leftover 4 件（nested STRUCT_GET / hashmap_new DCE / linear `ref.func`）はすべてこの s2 で MATCH。

### 6d / 6e

linear key path + `gc_hint` FAIL=0。

### leftover T3 preflight (not full T3)

公式 WAT と並列しないようフル T3 は未実行。`resume-leftover-t3.sh` は VF 生存で EXIT 2。
wave 1 + wave 2 = **24/24 PASS**、すべて `name=0 fallback=0`（enum/struct/hashmap/closure/generics/`?`/type_table）。

## 修正

- `inst_dispatch_const.ark`: linear の `MIR_REF_FUNC` は table index の `i32.const`
- `intrinsic_hashmap_str_new.ark`: DCE された `hashmap_new` の代わりに Vec フラット layout を inline
- `inst_dispatch_struct.ark` + `inst_struct_record.ark`: 入れ子 field のあと linear `STRUCT_GET` が `arg0` から base を載せる

## 残作業

公式 VF は WAT 中。完了後にフル leftover T3、PR 51 のあと clock-qmark へ入れ、最終 pin で 6a–6f を再証明。`#686` / `#801` / `#721` はまだ close しない。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-519b4bd0-f055-42fc-9a1f-0e86f4e941a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-519b4bd0-f055-42fc-9a1f-0e86f4e941a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

